### PR TITLE
Fix Critical Hit special rule implementation

### DIFF
--- a/src/engine/__tests__/challengeEngine.test.ts
+++ b/src/engine/__tests__/challengeEngine.test.ts
@@ -70,17 +70,15 @@ describe('ChallengeEngine', () => {
     const dice = new FakeDiceRoller([
       // Seize focus: player [6,6] keep highest = 6; ai [1]
       6, 6, 1,
-      // strike: d3=1, 7 hits (all 6), 7 wounds (all 6), 7 saves (all 1)
-      1,
-      6,6,6,6,6,6,6,
-      6,6,6,6,6,6,6,
+      // strike: 7 hits of 5 (5 ≥ hitTN 2+; 5 ≥ critThreshold 5+ → all Critical Hits)
+      // Critical Hits auto-wound, no wound dice. 7 crit saves (all 1s → fail Inv 4+).
+      // 7 unsaved crit wounds × D(2+1)−EW(1)=D2 = 14 > W4 → casualty.
+      5,5,5,5,5,5,5,
       1,1,1,1,1,1,1,
     ]);
 
     const state = runToEnd(dice);
     expect(state.phase).toBe('ended');
-    // Warboss W=4; total dmg after EW(1): min 1 per wound
-    // 7 unsaved × 1 dmg = 7 > 4 → casualty
     expect(state.ai.isCasualty).toBe(true);
     expect(state.playerCRP).toBeGreaterThan(0);
   });

--- a/src/engine/__tests__/strikeStep.test.ts
+++ b/src/engine/__tests__/strikeStep.test.ts
@@ -39,17 +39,14 @@ function makeState(
 
 describe('resolveStrikeStep', () => {
   it('player attacks first when player has advantage', () => {
-    // Player (VALDOR, A=6+1bonus=7) rolls all 6s for hits (WS7 vs WS6 = 2+)
-    // Warboss saves: Sv4+ vs AP2 → penetrated; inv4+ available (not affected by AP)
-    // getEffectiveSave(4, 4, 2): AP2 ≤ Sv4 (penetrated), inv4+ available → 4+
-    // Provide: 7 hit dice, 7 wound dice (S7 vs T5 = 2+), 7 save dice (inv4+, all 1)
-    // EternalWarrior(1) on WARBOSS: D=max(1, 2-1)=1; 7 unsaved × 1 = 7 > W4 → casualty
-    // AI then has no attack (casualty)
+    // Player (VALDOR, A=6+1bonus=7) rolls 7 dice of 5 for hits (WS7 vs WS6 = 2+, 5 ≥ 2).
+    // Apollonian Spear has CriticalHit(5+): roll 5 ≥ 5 → every hit is a Critical Hit.
+    // Critical Hits auto-wound — no wound dice rolled.
+    // 7 unsaved crit wounds × D(2+1)−EW(1) = D2 each → 14 damage > W4 → casualty.
+    // AI then has no attack (casualty).
     const dice = new FakeDiceRoller([
-      1,              // d3 (getStrikeModifiers call; no flurry-of-blows)
-      6,6,6,6,6,6,6,  // 7 hit dice
-      6,6,6,6,6,6,6,  // 7 wound dice
-      1,1,1,1,1,1,1,  // 7 save dice (all fail vs inv4+)
+      5,5,5,5,5,5,5,  // 7 hit dice (5 ≥ hitTN 2+; 5 ≥ critThreshold 5+ → all Critical Hits)
+      1,1,1,1,1,1,1,  // 7 save dice (all fail vs Inv 4+)
     ]);
 
     const state = makeState();
@@ -63,17 +60,16 @@ describe('resolveStrikeStep', () => {
   });
 
   it('Flurry of Blows: damage capped at 1 per wound', () => {
-    // Player uses Flurry of Blows; d3=3, so +3 attacks (total 6+1+3=10 on advantage)
-    // But damage must be set to 1 regardless of weapon D2.
-    // d3 is only consumed for flurry-of-blows gambits.
-    // VALDOR vs WARBOSS: AP2 penetrates Sv4+; Inv4+ available (not AP-affected) → saves at 4+
+    // Player uses Flurry of Blows; raw d3=5 → d3Result=3, so +3 attacks (6+1+3=10).
+    // Apollonian Spear CriticalHit(5+): all hit rolls of 5 are Critical Hits → auto-wound.
+    // No wound dice rolled (all hits are Critical).
+    // Flurry caps damage to 1 even for Critical Hits, so totalDamage === unsavedWounds.
+    // VALDOR vs WARBOSS: AP2 penetrates Sv4+; Inv4+ available → saves at 4+.
     const dice = new FakeDiceRoller([
-      3,              // d3 = 3 extra attacks (player has flurry-of-blows)
-      6,6,6,6,6,6,6,6,6,6, // 10 hit dice (all hit, WS7 vs WS6 = 2+)
-      6,6,6,6,6,6,6,6,6,6, // 10 wound dice (S7 vs T5 = 2+, all wound)
-      1,1,1,1,1,1,1,1,1,1, // 10 save dice (inv4+, roll 1s → all fail)
-      // AI (6 attacks, no flurry, no d3 consumed): WS6 vs WS7 → 5+; roll 1s → miss
-      1,1,1,1,1,1, // AI 6 attack hit dice
+      5,              // d3 raw=5 → d3Result=3 extra attacks (flurry-of-blows)
+      5,5,5,5,5,5,5,5,5,5, // 10 hit dice (5 ≥ hitTN 2+; 5 ≥ critThreshold 5+ → all crits)
+      // No wound dice — all hits are Critical Hits (auto-wound)
+      1,1,1,1,1,1,1,1,1,1, // 10 save dice (Inv4+, roll 1s → all fail)
     ]);
 
     const state = makeState(VALDOR, WARBOSS, {
@@ -172,12 +168,11 @@ describe('resolveStrikeStep', () => {
   });
 
   it('model becomes a casualty when wounds reach 0', () => {
-    // Force Warboss to take more damage than his 4 wounds
+    // Apollonian Spear CriticalHit(5+): rolls of 5 hit (WS7 vs WS6 = 2+) and are crits.
+    // Critical Hits auto-wound — no wound dice. 7 crit unsaved wounds × D2 = 14 > W4 → casualty.
     const dice = new FakeDiceRoller([
-      1,                          // d3
-      6,6,6,6,6,6,6,              // 7 hits
-      6,6,6,6,6,6,6,              // 7 wounds
-      1,1,1,1,1,1,1,              // 7 failed saves
+      5,5,5,5,5,5,5,              // 7 hits (5 ≥ 2+) and crits (5 ≥ 5+) — no wound rolls
+      1,1,1,1,1,1,1,              // 7 failed saves (Inv 4+)
     ]);
     const state = makeState();
     const result = resolveStrikeStep(dice, state, VALDOR, WARBOSS, 'player');
@@ -186,14 +181,12 @@ describe('resolveStrikeStep', () => {
   });
 
   it('FeelNoPain(5+): cancels some wounds, remainder cause damage and kill AI', () => {
-    // VALDOR (WS7, A6, +1 advantage=7 attacks) vs Warboss+FNP(5+) (W4, EW1, Sv4, Inv4).
-    // VALDOR uses Apollonian Spear: SM+2 → S6, AP2, D2, CriticalHit(5+).
-    // No d3 consumed (no flurry-of-blows).
-    // Hit TN: WS7 vs WS6 = 2+. 7 rolls of 6 → 7 hits.
-    // Wound TN: S6 vs T5 = 3+. 7 rolls of 6 → 7 wounds.
-    // Save: AP2 negates Sv4; Inv4+ used. 7 rolls of 1 → all fail.
-    // FNP(5+): 5,5,5,1,1,1,1 → 3 cancelled, 4 fail.
-    // Damage: D2 - EW(1) = max(1,1) = 1 per wound. 4 × 1 = 4 damage. W4→0 → CASUALTY.
+    // VALDOR (WS7, A6+1adv=7 attacks) vs Warboss+FNP(5+) (W4, EW1, Sv4, Inv4).
+    // Apollonian Spear: CriticalHit(5+), D2. Rolls of 6 hit (≥2+) and crit (≥5+).
+    // Critical Hits auto-wound (no wound dice). 7 crit wounds, saves at Inv4+.
+    // 7 save rolls of 1 → all fail → 7 unsaved crit wounds.
+    // FNP(5+): 5,5,5,1,1,1,1 → 3 cancelled (proportional), 4 remain.
+    // Damage: crit D(2+1)−EW(1)=D2 per wound. 4 × 2 = 8 > W4 → CASUALTY.
     // AI doesn't attack.
     const defenderWithFNP: Character = {
       ...WARBOSS,
@@ -205,11 +198,10 @@ describe('resolveStrikeStep', () => {
     };
     const state = makeState(VALDOR, defenderWithFNP);
     const dice = new FakeDiceRoller([
-      // No d3 (gambit is null, not flurry-of-blows)
-      6,6,6,6,6,6,6,  // 7 hit rolls (TN 2+, all hit)
-      6,6,6,6,6,6,6,  // 7 wound rolls (TN 3+, all wound)
+      6,6,6,6,6,6,6,  // 7 hit rolls (TN 2+, all hit; 6 ≥ critThreshold 5+ → all Critical Hits)
+      // No wound dice — Critical Hits auto-wound without dice
       1,1,1,1,1,1,1,  // 7 save rolls (Inv4+, all fail)
-      5,5,5,1,1,1,1,  // 7 FNP rolls: 3 succeed → 4 through
+      5,5,5,1,1,1,1,  // 7 FNP rolls: 3 succeed → 4 unsaved
     ]);
     const result = resolveStrikeStep(dice, state, VALDOR, defenderWithFNP, 'player');
     expect(result.playerResult.unsavedWounds).toBe(4);
@@ -345,6 +337,76 @@ describe('resolveStrikeStep', () => {
     expect(result.updatedState.ai.isCasualty).toBe(true);
     expect(result.playerResult.hitRollOnes).toBe(1);
     expect(result.updatedState.player.currentWounds).toBe(2); // W3 - 1 self-wound = 2
+  });
+
+  it('CriticalHit: auto-wounds on crit, +1 Damage, no crit on a miss', () => {
+    // Use a custom attacker (WS7, S4, A2+1bonus=3) with a CriticalHit(5+)/D2 weapon
+    // vs a custom defender (WS2, T4, Sv7 = no armour, Inv4+, W6, no EW).
+    // hitTN = WS7 vs WS2 = 2+.
+    //
+    // Hit dice: [6, 3, 1]
+    //   6: 6 ≥ 2+ → hit; 6 ≥ 5+ → Critical Hit  (auto-wound, D2+1=3)
+    //   3: 3 ≥ 2+ → hit; 3 <  5  → normal hit    (goes through wound test)
+    //   1: 1 < 2  → miss; Critical Hit rule CANNOT apply on a miss
+    //
+    // Wound dice (1 die for the single normal hit): [5]
+    //   S4 vs T4 = 4+. Roll 5 ≥ 4+ → wound.
+    //
+    // Saves: no armour (Sv7), Inv4+. effectiveSave = 4+.
+    //   Pool 1 (crit wound at weapon AP): [1] → fail → unsavedCritWounds=1
+    //   Pool 2 (normal wound at weapon AP): [1] → fail
+    //
+    // Damage:
+    //   critDmgPerWound = max(1, (2+0+1)−0) = 3   (D2 + Critical Hit +1, no EW)
+    //   dmgPerWound     = max(1, (2+0)−0)   = 2   (D2 normal)
+    //   totalDamage = 1×3 + 1×2 = 5
+    const attacker = {
+      ...WARBOSS,
+      id: 'crit-test-attacker',
+      stats: { ...WARBOSS.stats, WS: 7, S: 4, A: 2, W: 4, Inv: null },
+      specialRules: [],
+    };
+    const defender = {
+      ...WARBOSS,
+      id: 'crit-test-defender',
+      stats: { ...WARBOSS.stats, WS: 2, T: 4, Sv: 7, Inv: 4, W: 6 },
+      specialRules: [],
+    };
+    const critWeapon = {
+      profileName: 'Crit Test Weapon',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: null, damage: 2,
+      specialRules: [{ name: 'CriticalHit' as const, threshold: 5 }],
+    };
+    const state: CombatState = {
+      ...makeState(attacker, defender),
+      challengeAdvantage: 'player',
+      player: {
+        ...makeState(attacker, defender).player,
+        selectedWeaponProfile: critWeapon,
+      },
+      ai: {
+        ...makeState(attacker, defender).ai,
+        selectedWeaponProfile: defender.weapons[0].profiles[0],
+      },
+    };
+    const dice = new FakeDiceRoller([
+      6, 3, 1,   // 3 hit rolls: crit hit, normal hit, miss
+      5,         // 1 wound roll for the normal hit (S4 vs T4 = 4+, roll 5 → wound)
+      1,         // crit wound save (Inv4+, fail)
+      1,         // normal wound save (Inv4+, fail)
+      // AI doesn't kill player (defender has no meaningful attack — all 1s)
+      1,1,1,1,1,1, // 6 AI hit rolls, all miss
+    ]);
+    const result = resolveStrikeStep(dice, state, attacker, defender, 'player');
+
+    expect(result.playerResult.hits).toBe(2);        // crit hit + normal hit; miss is NOT a hit
+    expect(result.playerResult.wounds).toBe(2);      // 1 crit auto-wound + 1 normal wound
+    expect(result.playerResult.unsavedWounds).toBe(2);
+    // Critical Hit deals +1D: crit wound = D3, normal wound = D2. Total = 3+2 = 5.
+    expect(result.playerResult.totalDamage).toBe(5);
   });
 
   it('Mirror-Form: hits always on 4+ regardless of WS comparison', () => {

--- a/src/engine/strikeStep.ts
+++ b/src/engine/strikeStep.ts
@@ -145,6 +145,7 @@ function resolveAttackSequence(
   const hitTN = mirrorFormActive ? 4 : getHitTargetNumber(atkWS, defWS);
   const hitRolls = dice.rollNd6(atkA);
   let hits = 0;
+  let critHits = 0;
   let guardUpMissCount = 0;
   let hitRollOnes = 0; // for Biological Overload self-wound tracking
 
@@ -154,25 +155,30 @@ function resolveAttackSequence(
 
     const isHit = hitTN <= 6 && roll >= hitTN;
 
-    // Check for Critical Hit special rule (extra wound on high roll)
-    // Sources: weapon special rules AND gambit modifiers (e.g., Executioner's Tax, Death's Champion)
-    let critHit = false;
-    for (const sr of profile.specialRules) {
-      if (sr.name === 'CriticalHit' && roll >= sr.threshold) critHit = true;
-    }
-    if (mods.criticalHitThreshold !== null && roll >= mods.criticalHitThreshold) {
-      critHit = true;
+    // Critical Hit only applies when a hit is actually inflicted by this Hit Test
+    // (rule: "if a Hit is inflicted by that Hit Test, that Hit becomes a Critical Hit")
+    let isCrit = false;
+    if (isHit) {
+      for (const sr of profile.specialRules) {
+        if (sr.name === 'CriticalHit' && roll >= sr.threshold) isCrit = true;
+      }
+      if (mods.criticalHitThreshold !== null && roll >= mods.criticalHitThreshold) {
+        isCrit = true;
+      }
     }
 
-    if (isHit || critHit) {
+    if (isHit) {
       hits++;
+      if (isCrit) critHits++;
     } else {
       // Missed – Guard Up bonus for next Focus Roll
       if (defender.selectedGambit === 'guard-up') guardUpMissCount++;
     }
   }
 
-  log.push(`Hit rolls [${hitRolls.join(',')}] needing ${hitTN}+ → ${hits} hit(s)`);
+  const normalHits = hits - critHits;
+  const critHitNote = critHits > 0 ? ` (${critHits} critical)` : '';
+  log.push(`Hit rolls [${hitRolls.join(',')}] needing ${hitTN}+ → ${hits} hit(s)${critHitNote}`);
 
   if (hits === 0) {
     const defWounds = defender.currentWounds;
@@ -196,10 +202,23 @@ function resolveAttackSequence(
     if (sr.name === 'Poisoned') poisonedTN = sr.threshold;
   }
 
-  const woundRolls = dice.rollNd6(hits);
-  let wounds          = 0;
-  let breachingWounds = 0;  // wounds treated as AP2 (Breaching rule)
-  let shredTriggers   = 0;  // wounds that deal +1 Damage (Shred rule)
+  // Critical hits automatically inflict a wound without any dice being rolled,
+  // counting as a roll of 6 for variable special rules (Breaching, Shred) triggered
+  // by the Wound Test.
+  let critBreachingWounds = 0;
+  let critShredTriggers   = 0;
+  for (const sr of profile.specialRules) {
+    if (sr.name === 'Breaching' && 6 >= sr.threshold) critBreachingWounds += critHits;
+    if (sr.name === 'Shred'     && 6 >= sr.threshold) critShredTriggers   += critHits;
+  }
+  critBreachingWounds = Math.min(critBreachingWounds, critHits);
+  const critWounds = critHits;
+
+  // Normal hits go through the wound test as usual
+  const woundRolls = dice.rollNd6(normalHits);
+  let normalWounds          = 0;
+  let normalBreachingWounds = 0;  // wounds treated as AP2 (Breaching rule)
+  let normalShredTriggers   = 0;  // wounds that deal +1 Damage (Shred rule)
   // Phage(T): Merciless Strike reduces defender T by 1 per unsaved wound
   let currentDefT = effectiveDefT;
 
@@ -220,21 +239,29 @@ function resolveAttackSequence(
       if (sr.name === 'Rending' && roll >= sr.threshold) isWound = true;
     }
     if (isWound) {
-      wounds++;
+      normalWounds++;
       if (mods.phageToughness) currentDefT = Math.max(1, currentDefT - 1);
       for (const sr of profile.specialRules) {
         // Breaching: wound roll ≥ threshold → this wound ignores normal armour (AP2)
-        if (sr.name === 'Breaching' && roll >= sr.threshold) breachingWounds++;
+        if (sr.name === 'Breaching' && roll >= sr.threshold) normalBreachingWounds++;
         // Shred: wound roll ≥ threshold → this wound gains +1 Damage
-        if (sr.name === 'Shred'     && roll >= sr.threshold) shredTriggers++;
+        if (sr.name === 'Shred'     && roll >= sr.threshold) normalShredTriggers++;
       }
     }
   }
 
+  const wounds               = critWounds + normalWounds;
+  const totalBreachingWounds = critBreachingWounds + normalBreachingWounds;
+
   const phageNote    = mods.phageToughness ? ' (Phage: T reduces per wound)' : '';
   const poisonNote   = poisonedTN !== null ? ` (Poisoned ${poisonedTN}+, table ${baseWoundTN})` : '';
   const effectiveWoundTN = poisonedTN !== null ? Math.min(baseWoundTN, poisonedTN) : baseWoundTN;
-  log.push(`Wound rolls [${woundRolls.join(',')}] needing ${effectiveWoundTN}+${poisonNote}${phageNote} → ${wounds} wound(s)`);
+  if (critWounds > 0) {
+    log.push(`${critHits} Critical Hit(s) → ${critWounds} automatic wound(s) (counts as roll of 6)`);
+  }
+  if (normalHits > 0) {
+    log.push(`Wound rolls [${woundRolls.join(',')}] needing ${effectiveWoundTN}+${poisonNote}${phageNote} → ${normalWounds} wound(s)`);
+  }
 
   if (wounds === 0) {
     return {
@@ -250,16 +277,38 @@ function resolveAttackSequence(
   // ── Saving Throws ────────────────────────────────────────────────────────
   const defSv  = defenderChar.stats.Sv;
   const defInv = defenderChar.stats.Inv;
-  const normalWounds  = wounds - breachingWounds;
+  // Split wounds into four save pools: (crit | normal) × (weapon AP | AP2 breaching)
+  const critNormalCount = critWounds - critBreachingWounds;
+  const normNormalCount = normalWounds - normalBreachingWounds;
   const effectiveSave = getEffectiveSave(defSv, defInv, weaponAP);
   // Breaching wounds are always treated as AP2 for saves regardless of weapon AP
-  const breachSave    = breachingWounds > 0 ? getEffectiveSave(defSv, defInv, 2) : null;
+  const breachSave    = totalBreachingWounds > 0 ? getEffectiveSave(defSv, defInv, 2) : null;
 
-  let saved    = 0;
-  let evsfUsed = false; // Every Strike Foreseen may only re-roll ONE failed save
+  let saved             = 0;
+  let unsavedCritWounds = 0;
+  let evsfUsed          = false; // Every Strike Foreseen may only re-roll ONE failed save
 
-  // Normal wounds — saved against weapon AP
-  const normalSaveRolls = dice.rollNd6(normalWounds);
+  // Pool 1: crit wounds at weapon AP — track each failure as an unsaved crit wound
+  const critNormSaveRolls = dice.rollNd6(critNormalCount);
+  if (effectiveSave !== null) {
+    for (let i = 0; i < critNormSaveRolls.length; i++) {
+      let roll = critNormSaveRolls[i];
+      if (everyStrikeActive && !evsfUsed && roll < effectiveSave) {
+        const reroll = dice.rollD6();
+        log.push(`Every Strike Foreseen: re-roll save ${roll} → ${reroll}`);
+        critNormSaveRolls[i] = reroll;
+        roll = reroll;
+        evsfUsed = true;
+      }
+      if (roll >= effectiveSave) saved++;
+      else unsavedCritWounds++;
+    }
+  } else {
+    unsavedCritWounds += critNormalCount;
+  }
+
+  // Pool 2: normal wounds at weapon AP
+  const normalSaveRolls = dice.rollNd6(normNormalCount);
   if (effectiveSave !== null) {
     for (let i = 0; i < normalSaveRolls.length; i++) {
       let roll = normalSaveRolls[i];
@@ -274,15 +323,34 @@ function resolveAttackSequence(
     }
   }
 
-  // Breaching wounds — always AP2
-  const breachSaveRolls = dice.rollNd6(breachingWounds);
+  // Pool 3: crit breaching wounds at AP2 — track failures as unsaved crit wounds
+  const critBreachSaveRolls = dice.rollNd6(critBreachingWounds);
   if (breachSave !== null) {
-    for (let i = 0; i < breachSaveRolls.length; i++) {
-      let roll = breachSaveRolls[i];
+    for (let i = 0; i < critBreachSaveRolls.length; i++) {
+      let roll = critBreachSaveRolls[i];
       if (everyStrikeActive && !evsfUsed && roll < breachSave) {
         const reroll = dice.rollD6();
         log.push(`Every Strike Foreseen: re-roll save ${roll} → ${reroll}`);
-        breachSaveRolls[i] = reroll;
+        critBreachSaveRolls[i] = reroll;
+        roll = reroll;
+        evsfUsed = true;
+      }
+      if (roll >= breachSave) saved++;
+      else unsavedCritWounds++;
+    }
+  } else {
+    unsavedCritWounds += critBreachingWounds;
+  }
+
+  // Pool 4: normal breaching wounds at AP2
+  const normBreachSaveRolls = dice.rollNd6(normalBreachingWounds);
+  if (breachSave !== null) {
+    for (let i = 0; i < normBreachSaveRolls.length; i++) {
+      let roll = normBreachSaveRolls[i];
+      if (everyStrikeActive && !evsfUsed && roll < breachSave) {
+        const reroll = dice.rollD6();
+        log.push(`Every Strike Foreseen: re-roll save ${roll} → ${reroll}`);
+        normBreachSaveRolls[i] = reroll;
         roll = reroll;
         evsfUsed = true;
       }
@@ -290,11 +358,13 @@ function resolveAttackSequence(
     }
   }
 
-  const saveRolls = [...normalSaveRolls, ...breachSaveRolls];
+  const saveRolls = [...critNormSaveRolls, ...normalSaveRolls, ...critBreachSaveRolls, ...normBreachSaveRolls];
   if (effectiveSave !== null || breachSave !== null) {
-    const saveLine = breachingWounds > 0
-      ? `Normal saves [${normalSaveRolls.join(',')}] vs ${effectiveSave ?? '-'}+, Breaching saves [${breachSaveRolls.join(',')}] vs ${breachSave ?? '-'}+ → ${saved} saved`
-      : `Save rolls [${normalSaveRolls.join(',')}] vs ${effectiveSave}+ → ${saved} saved`;
+    const allNormRolls   = [...critNormSaveRolls, ...normalSaveRolls];
+    const allBreachRolls = [...critBreachSaveRolls, ...normBreachSaveRolls];
+    const saveLine = totalBreachingWounds > 0
+      ? `Normal saves [${allNormRolls.join(',')}] vs ${effectiveSave ?? '-'}+, Breaching saves [${allBreachRolls.join(',')}] vs ${breachSave ?? '-'}+ → ${saved} saved`
+      : `Save rolls [${allNormRolls.join(',')}] vs ${effectiveSave}+ → ${saved} saved`;
     log.push(saveLine);
   } else {
     log.push(`No save available (AP${weaponAP ?? '-'} vs Sv${defSv}+/Inv${defInv ?? '-'})`);
@@ -312,7 +382,14 @@ function resolveAttackSequence(
     const fnpRolls = dice.rollNd6(unsavedWounds);
     const fnpSaved = fnpRolls.filter(r => r >= fnpThreshold!).length;
     log.push(`Feel No Pain ${fnpThreshold}+: rolls [${fnpRolls.join(',')}] → ${fnpSaved} wound(s) cancelled`);
+    // Distribute FNP cancels proportionally between crit and normal unsaved wounds
+    const fnpCritCancelled = unsavedWounds > 0
+      ? Math.min(unsavedCritWounds, Math.round((unsavedCritWounds / unsavedWounds) * fnpSaved))
+      : 0;
+    unsavedCritWounds = Math.max(0, unsavedCritWounds - fnpCritCancelled);
     unsavedWounds -= fnpSaved;
+    // Clamp for rounding safety
+    unsavedCritWounds = Math.min(unsavedCritWounds, unsavedWounds);
   }
 
   if (unsavedWounds === 0) {
@@ -341,25 +418,37 @@ function resolveAttackSequence(
   }
   dmgPerWound = Math.max(1, dmgPerWound - ewReduction);
 
+  // Critical Hit wounds increase the Damage Characteristic by +1 (before EW reduction).
+  // When Flurry of Blows caps damage to 1, the crit bonus is suppressed by the cap.
+  const critDmgPerWound = mods.damageSetToOne
+    ? 1
+    : Math.max(1, (baseDmg + mods.damageDelta + 1) - ewReduction);
+
   // Shred: wounds that triggered Shred deal +1 Damage (suppressed when Flurry caps D to 1).
-  // We don't track which specific unsaved wounds came from Shred rolls, so we approximate:
-  // the fraction (shredTriggers / wounds) of all unsaved wounds are treated as Shred wounds.
-  const unsavedShredWounds = wounds > 0 && !mods.damageSetToOne
-    ? Math.round((shredTriggers / wounds) * unsavedWounds)
+  // Applied only to normal (non-critical) unsaved wounds; crit wounds already get +1D.
+  // We don't track which specific unsaved normal wounds came from Shred rolls, so approximate
+  // with the fraction (normalShredTriggers / normalWounds) of normal unsaved wounds.
+  const unsavedNormalWounds = unsavedWounds - unsavedCritWounds;
+  const unsavedShredWounds = normalWounds > 0 && !mods.damageSetToOne
+    ? Math.round((normalShredTriggers / normalWounds) * unsavedNormalWounds)
     : 0;
   const shredDmgPerWound = Math.max(1, (baseDmg + mods.damageDelta + 1) - ewReduction);
   const totalDamage =
-    (unsavedWounds - unsavedShredWounds) * dmgPerWound +
+    unsavedCritWounds * critDmgPerWound +
+    (unsavedNormalWounds - unsavedShredWounds) * dmgPerWound +
     unsavedShredWounds * shredDmgPerWound;
 
   const defenderWoundsRemaining = Math.max(0, defender.currentWounds - totalDamage);
   const defenderIsCasualty = defenderWoundsRemaining <= 0;
 
+  const critDmgNote = unsavedCritWounds > 0
+    ? ` (${unsavedCritWounds} critical × D${critDmgPerWound})`
+    : '';
   const shredNote = unsavedShredWounds > 0
     ? ` (${unsavedShredWounds} Shred wound(s) at +1 dmg)`
     : '';
   log.push(
-    `${unsavedWounds} unsaved wound(s) × ${dmgPerWound} dmg${shredNote} = ${totalDamage} damage. ` +
+    `${unsavedWounds} unsaved wound(s) × ${dmgPerWound} dmg${critDmgNote}${shredNote} = ${totalDamage} damage. ` +
     `${defenderChar.name}: ${defender.currentWounds} → ${defenderWoundsRemaining} wounds` +
     (defenderIsCasualty ? ' (CASUALTY)' : ''),
   );

--- a/src/models/weapon.ts
+++ b/src/models/weapon.ts
@@ -25,7 +25,7 @@ export type AttacksModifier    = CharModifier;
 /** Special rules that directly affect challenge combat resolution. */
 export type SpecialRule =
   | { name: 'DuellistsEdge';    value: number }      // +X to Focus Roll
-  | { name: 'CriticalHit';      threshold: number }  // extra wound on roll ≥ threshold
+  | { name: 'CriticalHit';      threshold: number }  // hit becomes a Critical Hit when roll ≥ threshold (auto-wounds, +1D)
   | { name: 'EternalWarrior';   value: number }      // reduce unsaved wound damage by X (min 1)
   | { name: 'Rending';          threshold: number }  // AP 2 on roll ≥ threshold
   | { name: 'Impact';           modifier: CharModifier } // bonus attacks on charge (out of scope for Challenge)


### PR DESCRIPTION
Three bugs corrected in resolveAttackSequence (strikeStep.ts):

1. A Critical Hit can only occur when a hit is actually inflicted. The old `if (isHit || critHit)` condition allowed a miss that met the threshold to count as a hit, violating the rule "if a Hit is inflicted by that Hit Test, that Hit becomes a Critical Hit".

2. Critical Hits now auto-wound without rolling wound dice, as required by the rule "automatically inflicts a wound without any Dice being rolled". Wound dice are only rolled for normal (non-critical) hits. Critical wounds count as a roll of 6 for variable special rules (Breaching, Shred) triggered by the Wound Test.

3. Critical Hit wounds now deal +1 to the Damage Characteristic (before Eternal Warrior reduction, min 1), as required by the rule "increases the Damage Characteristic of the Hit by +1".

Implementation: track critHits separately in the hit loop; auto-wound crit hits and check Breaching/Shred as if wound roll = 6; split saves into four pools (crit/normal × weapon-AP/AP2) to track unsavedCritWounds exactly; apply critDmgPerWound = max(1, baseDmg+1+damageDelta−ewReduction) to unsaved critical wounds.

Update affected test dice sequences (wound rolls no longer consumed for all-critical hit sequences) and add a dedicated Critical Hit test that verifies: miss cannot become a crit, normal hit goes through wound test, crit auto-wounds without dice, and crit damage equals baseDmg+1.