### PR TITLE
Add 'The Undying Fire' gambit for Salamanders (Vulkan)

### DIFF
--- a/src/data/factions/loyalistLegions.ts
+++ b/src/data/factions/loyalistLegions.ts
@@ -511,7 +511,7 @@ const VULKAN: Character = {
     Sv: 2, Inv: 4,
   },
   weapons: [DAWNBRINGER],
-  factionGambitIds: ['duty-is-sacrifice'],
+  factionGambitIds: ['duty-is-sacrifice', 'the-undying-fire'],
   specialRules: [
     { name: 'EternalWarrior', value: 3 },
     { name: 'Bulky', value: 5 },

--- a/src/data/gambits/loyalistLegions.ts
+++ b/src/data/gambits/loyalistLegions.ts
@@ -183,6 +183,14 @@ export const SALAMANDERS_GAMBITS: Gambit[] = [
     firstMoverOnly: false,
     oncePerChallenge: false,
   },
+  {
+    id: 'the-undying-fire',
+    name: 'The Undying Fire',
+    description: 'No positive modifiers may be applied to this model\'s Focus Roll. If this model is not reduced to 0 Wounds in the Strike Step, it regains D3 Wounds (max Base Wounds) before the Glory Step or next round begins. Regained Wounds do not affect Combat Resolution.',
+    timings: ['focus', 'glory'],
+    firstMoverOnly: false,
+    oncePerChallenge: false,
+  },
 ];
 
 // ── Raven Guard (XIX) ────────────────────────────────────────────────────────

--- a/src/engine/__tests__/challengeEngine.test.ts
+++ b/src/engine/__tests__/challengeEngine.test.ts
@@ -3,9 +3,11 @@ import { ChallengeEngine, buildInitialState } from '../challengeEngine.js';
 import { FakeDiceRoller } from '../dice.js';
 import { CUSTODES_CHARACTERS } from '../../data/factions/custodes.js';
 import { ORK_CHARACTERS } from '../../data/factions/orks.js';
+import { LOYALIST_LEGION_CHARACTERS } from '../../data/factions/loyalistLegions.js';
 
 const VALDOR  = CUSTODES_CHARACTERS.find(c => c.id === 'constantin-valdor')!;
 const WARBOSS = ORK_CHARACTERS.find(c => c.id === 'warboss-goffs')!;
+const VULKAN  = LOYALIST_LEGION_CHARACTERS.find(c => c.id === 'vulkan')!;
 
 /**
  * Run the engine until it reaches 'ended' or maxRounds, feeding fixed input
@@ -122,6 +124,49 @@ describe('ChallengeEngine', () => {
     expect(state.phase).toBe('ended');
     expect(state.playerCRP).toBe(0);
     expect(state.aiCRP).toBe(0);
+  });
+
+  it('The Undying Fire: D3 wounds regained after surviving the Strike Step', () => {
+    // Player (VULKAN, W7) starts at W6 (pre-injured by 1) to make healing visible.
+    // All attacks miss on both sides.  D3 raw=1 → D3 result=1 → player heals 1 wound → W7.
+    //
+    // Focus: player [1] + CI5 = 6; AI [5,(spare)] + CI4 = 9 → AI wins.
+    // The Undying Fire suppresses positive Focus modifiers (guardUpBonus=0 enforced).
+    // Strike: 20 × 1 covers any AI gambit dice (flurry D3=1) + AI attacks (all 1s miss TN5+)
+    //         + VULKAN attacks (all 1s miss TN3+).
+    // Heal: raw=1 → D3=1 → player.currentWounds = min(6+1, 7) = 7.
+    const dice = new FakeDiceRoller([
+      1, 5, 1,                           // focus: player [1]; AI [5, (spare if seize)]
+      1,1,1,1,1,1,1,1,1,1,               // strike padding: AI attacks/D3 (all 1s → miss)
+      1,1,1,1,1,1,                       // VULKAN: 6 attack dice (all 1s → miss)
+      1,                                 // D3 heal raw=1 → D3=1 → heal 1 wound
+    ]);
+
+    const engine = new ChallengeEngine(VULKAN, WARBOSS, dice);
+    let state = buildInitialState(VULKAN, WARBOSS);
+    // Pre-reduce player to 6 wounds so healing has a measurable effect
+    state = { ...state, player: { ...state.player, currentWounds: 6 } };
+
+    // faceOff: player picks 'the-undying-fire'
+    let r = engine.advance(state, { selectedGambit: 'the-undying-fire' });
+    state = r.state;
+
+    // focus: weapon selection (Dawnbringer)
+    r = engine.advance(state, { selectedWeaponIndex: 0, selectedProfileIndex: 0 });
+    state = r.state;
+
+    // Advance through strike
+    while (state.phase !== 'glory' && state.phase !== 'ended') {
+      r = engine.advance(state);
+      state = r.state;
+    }
+
+    // Healing is applied in the strike→glory transition, before Glory Step CRP resolution
+    expect(state.phase).toBe('glory');
+    expect(state.player.currentWounds).toBe(7);  // W6 + D3(1) = 7, capped at baseW7
+    expect(state.player.baseWounds).toBe(7);      // baseWounds never changes
+    expect(state.ai.woundsInflictedThisChallenge).toBe(0); // AI inflicted 0 (all missed)
+    // CRP for this round = AI wins 0 vs player 0 → draw (no wounds inflicted)
   });
 
   it('Test the Foe: advantage carries to next round', () => {

--- a/src/engine/__tests__/gambitEffects.test.ts
+++ b/src/engine/__tests__/gambitEffects.test.ts
@@ -148,6 +148,29 @@ describe('Biological Overload gambit', () => {
   });
 });
 
+describe('The Undying Fire gambit', () => {
+  const state = buildInitialState(VALDOR, WARBOSS);
+
+  it('Focus: suppressPositiveModifiers=true, no extra dice, no flat bonus', () => {
+    const mod = getFocusDiceModification('the-undying-fire');
+    expect(mod.suppressPositiveModifiers).toBe(true);
+    expect(mod.extraDice).toBe(0);
+    expect(mod.discardLowest).toBe(false);
+    expect(mod.flatBonus).toBe(0);
+    expect(mod.suppressWoundPenalties).toBe(false);
+  });
+
+  it('Strike: returns base modifiers (wound healing is in challenge engine, not strike)', () => {
+    const mods = getStrikeModifiers('the-undying-fire', state, true);
+    expect(mods.wsDelta).toBe(0);
+    expect(mods.attacksDelta).toBe(0);
+    expect(mods.strengthDelta).toBe(0);
+    expect(mods.damageDelta).toBe(0);
+    expect(mods.damageSetToOne).toBe(false);
+    expect(mods.singleAttackCap).toBe(false);
+  });
+});
+
 describe('Mirror-Form gambit', () => {
   const state = buildInitialState(VALDOR, WARBOSS);
 

--- a/src/engine/challengeEngine.ts
+++ b/src/engine/challengeEngine.ts
@@ -261,8 +261,38 @@ export class ChallengeEngine {
       next = addLog(next, msg, msg.includes('CASUALTY') ? 'danger' : 'info');
     }
 
+    // The Undying Fire: if model survived the Strike Step (not a casualty), it
+    // regains D3 Wounds (max Base Wounds) before entering the Glory Step.
+    // Regained wounds do not alter the opponent's woundsInflictedThisChallenge.
+    next = this.applyUndyingFireHealing(next);
+
     next = { ...next, phase: 'glory' };
     return { state: next, waitingForInput: false };
+  }
+
+  /** Apply The Undying Fire D3 wound healing for any combatant with this gambit. */
+  private applyUndyingFireHealing(state: CombatState): CombatState {
+    let next = state;
+    for (const side of ['player', 'ai'] as const) {
+      const combatant = next[side];
+      if (combatant.selectedGambit !== 'the-undying-fire') continue;
+      if (combatant.isCasualty) continue;         // reduced to 0 Wounds → no healing
+      if (combatant.currentWounds >= combatant.baseWounds) continue; // already at full
+
+      const healRoll = this.dice.rollD3();
+      const before   = combatant.currentWounds;
+      const after    = Math.min(before + healRoll, combatant.baseWounds);
+      const actual   = after - before;
+      next = { ...next, [side]: { ...combatant, currentWounds: after } };
+      const label = side === 'player' ? 'Player' : 'AI';
+      next = addLog(
+        next,
+        `The Undying Fire (${label}): regains ${actual} wound(s)` +
+          ` (D3=${healRoll}; W${before}→${after}, max W${combatant.baseWounds}).`,
+        'success',
+      );
+    }
+    return next;
   }
 
   // ── strike-ai ────────────────────────────────────────────────────────────

--- a/src/engine/focusStep.ts
+++ b/src/engine/focusStep.ts
@@ -108,10 +108,13 @@ function rollFocus(
   const os = 0;
 
   const diceTotal = keptDice.reduce((a, b) => a + b, 0);
-  let total = buildFocusTotal(keptDice, ci, isHeavy, isLight, woundPenalty, de, os, guardUpBonus);
+  // The Undying Fire suppresses positive external modifiers (Guard Up bonus).
+  const effectiveGuardUpBonus = mod.suppressPositiveModifiers ? 0 : guardUpBonus;
+  let total = buildFocusTotal(keptDice, ci, isHeavy, isLight, woundPenalty, de, os, effectiveGuardUpBonus);
 
-  // Apply flat bonus from gambit (e.g., Paragon of Excellence, Howl of the Death Wolf)
-  total += mod.flatBonus;
+  // Apply flat bonus from gambit (e.g., Paragon of Excellence, Howl of the Death Wolf).
+  // For The Undying Fire this is 0, so no change needed.
+  total += mod.suppressPositiveModifiers ? Math.min(mod.flatBonus, 0) : mod.flatBonus;
 
   // Prophetic Duellist: may replace the entire total with Willpower if WP is higher
   if (mod.replaceWithWP) {

--- a/src/engine/gambitEffects.ts
+++ b/src/engine/gambitEffects.ts
@@ -45,6 +45,13 @@ export interface FocusDiceModification {
    * purpose of this Focus Roll (I Am Alpharius).
    */
   setOpponentCIToOne: boolean;
+  /**
+   * If true, all positive external modifiers to the Focus Roll are
+   * suppressed (Guard Up bonus, flat bonuses from other sources).
+   * The model still rolls 1d6 and adds its Combat Initiative.
+   * Used by The Undying Fire.
+   */
+  suppressPositiveModifiers: boolean;
 }
 
 /**
@@ -85,6 +92,7 @@ export function getFocusDiceModification(
     suppressWoundPenalties: false,
     replaceWithWP: false,
     setOpponentCIToOne: false,
+    suppressPositiveModifiers: false,
   };
 
   const round           = ctx.round          ?? 1;
@@ -158,6 +166,12 @@ export function getFocusDiceModification(
       // Player chooses +1/+2/+3; default to +2. Wounds applied in strike step.
       // A full UI for this choice would need additional input; we use +2 here.
       return { ...base, flatBonus: 2 };
+
+    case 'the-undying-fire':
+      // No positive modifiers may be applied to the Focus Roll.
+      // (The model still rolls 1d6 + CI and applies wound penalties.)
+      // Wound healing is resolved in the challenge engine after the Strike Step.
+      return { ...base, suppressPositiveModifiers: true };
 
     // ── Raven Guard ─────────────────────────────────────────────────────────
     case 'the-shadowed-lord':

--- a/src/models/gambit.ts
+++ b/src/models/gambit.ts
@@ -47,6 +47,7 @@ export type GambitId =
   | 'calculating-swordsman'   // Guilliman: +Focus equal to battle round number (max +4)
   // ── Salamanders (XVIII) ──────────────────────────────────────────────────
   | 'duty-is-sacrifice'       // all SA: choose +1/+2/+3 to Focus, suffer same wounds
+  | 'the-undying-fire'        // Vulkan: suppress positive Focus mods; survive Strike → regain D3 Wounds
   // ── Raven Guard (XIX) ────────────────────────────────────────────────────
   | 'decapitation-strike'     // all RG: once/challenge; no Focus Roll, one attack first
   | 'the-shadowed-lord'       // Corvus Corax: ignore wound penalties; may choose early Glory Step


### PR DESCRIPTION
Focus step: no positive modifiers may be applied — adds suppressPositiveModifiers flag to FocusDiceModification which zeroes the Guard Up bonus and any positive flat bonus; Combat Initiative and wound penalties still apply normally.

Glory step: if Vulkan survives the Strike Step (not reduced to 0 Wounds), a D3 healing roll is applied in the strike→glory transition (capped at base Wounds). Regained wounds do not affect the opponent's woundsInflictedThisChallenge, so Combat Resolution is unaltered as the rule requires.

Vulkan gains 'the-undying-fire' alongside 'duty-is-sacrifice' in factionGambitIds.