### PR TITLE
Implement 'Bulwark of the Imperium' gambit for Rogal Dorn

### DIFF
--- a/src/data/factions/loyalistLegions.ts
+++ b/src/data/factions/loyalistLegions.ts
@@ -240,7 +240,7 @@ const ROGAL_DORN: Character = {
     Sv: 2, Inv: 4,
   },
   weapons: [STORMS_TEETH],
-  factionGambitIds: ['a-wall-unyielding'],
+  factionGambitIds: ['a-wall-unyielding', 'bulwark-of-the-imperium'],
   specialRules: [
     { name: 'EternalWarrior', value: 2 },
     { name: 'Bulky', value: 4 },

--- a/src/data/gambits/loyalistLegions.ts
+++ b/src/data/gambits/loyalistLegions.ts
@@ -84,6 +84,14 @@ export const SPACE_WOLVES_GAMBITS: Gambit[] = [
 
 export const IMPERIAL_FISTS_GAMBITS: Gambit[] = [
   {
+    id: 'bulwark-of-the-imperium',
+    name: 'Bulwark of the Imperium',
+    description: 'Wound Tests made against this model with an unmodified result of 1, 2, 3 or 4 are never successful, regardless of the Strength Characteristic or any Special Rules that set the Target Number for Wound Tests (e.g. Poisoned). Critical Hits, which inflict automatic wounds without a dice roll, are unaffected.',
+    timings: ['strike'],
+    firstMoverOnly: false,
+    oncePerChallenge: false,
+  },
+  {
     id: 'a-wall-unyielding',
     name: 'A Wall Unyielding',
     description: 'This model does not add its Combat Initiative to the Focus Roll, but gains Eternal Warrior(1) for the duration of the following Strike Step.',

--- a/src/engine/__tests__/strikeStep.test.ts
+++ b/src/engine/__tests__/strikeStep.test.ts
@@ -5,6 +5,7 @@ import { buildInitialState } from '../challengeEngine.js';
 import { CUSTODES_CHARACTERS } from '../../data/factions/custodes.js';
 import { ORK_CHARACTERS } from '../../data/factions/orks.js';
 import { ASSASSIN_CHARACTERS } from '../../data/factions/assassins.js';
+import { LOYALIST_LEGION_CHARACTERS } from '../../data/factions/loyalistLegions.js';
 import type { CombatState } from '../../models/combatState.js';
 import type { Character } from '../../models/character.js';
 
@@ -13,6 +14,7 @@ const WARBOSS = ORK_CHARACTERS.find(c => c.id === 'warboss-goffs')!;
 const MEGA    = ORK_CHARACTERS.find(c => c.id === 'mega-warboss')!;
 const EVERSOR = ASSASSIN_CHARACTERS.find(c => c.id === 'eversor-assassin')!;
 const ADAMUS  = ASSASSIN_CHARACTERS.find(c => c.id === 'adamus-assassin')!;
+const DORN    = LOYALIST_LEGION_CHARACTERS.find(c => c.id === 'rogal-dorn')!;
 
 function makeState(
   playerChar = VALDOR,
@@ -407,6 +409,139 @@ describe('resolveStrikeStep', () => {
     expect(result.playerResult.unsavedWounds).toBe(2);
     // Critical Hit deals +1D: crit wound = D3, normal wound = D2. Total = 3+2 = 5.
     expect(result.playerResult.totalDamage).toBe(5);
+  });
+
+  it('Bulwark of the Imperium: wound rolls 1-4 always fail regardless of S vs T', () => {
+    // Custom attacker WS7 (hitTN 4+ vs DORN WS7), S8 (wound TN 3+ vs T6 normally).
+    // Bulwark forces minimum wound roll of 5: rolls 2,3,4 are blocked despite TN 3+.
+    // Wound rolls [2,3,4,5] → normally 3 wounds (≥ 3+), but Bulwark leaves only 1 (roll 5).
+    // AP2 negates DORN Sv2 → Inv4+ save. D2 - EW2 = max(1,0) = 1 damage per wound.
+    const attacker: Character = {
+      ...WARBOSS,
+      id: 'bulwark-test-attacker',
+      stats: { ...WARBOSS.stats, WS: 7, S: 8, A: 3, W: 4, Inv: null },
+      specialRules: [],
+    };
+    const bulwarkWeapon = {
+      profileName: 'Bulwark Test Weapon',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: 2, damage: 2,
+      specialRules: [],
+    };
+    const state: CombatState = {
+      ...makeState(attacker, DORN),
+      challengeAdvantage: 'player',
+      player: {
+        ...makeState(attacker, DORN).player,
+        selectedWeaponProfile: bulwarkWeapon,
+      },
+      ai: {
+        ...makeState(attacker, DORN).ai,
+        selectedGambit: 'bulwark-of-the-imperium',
+        selectedWeaponProfile: DORN.weapons[0].profiles[0],
+      },
+    };
+    const dice = new FakeDiceRoller([
+      5, 5, 5, 5,   // 4 hit rolls (A3 + advantage = 4 attacks; TN 4+, all hit)
+      2, 3, 4, 5,   // 4 wound rolls: Bulwark blocks 2,3,4; only 5 passes (normal TN 3+)
+      1,            // 1 save roll (AP2 → Inv4+, fail)
+      1,1,1,1,1,1,  // 6 DORN hit rolls (all miss, TN 4+)
+    ]);
+    const result = resolveStrikeStep(dice, state, attacker, DORN, 'player');
+    // Normally rolls 2,3,4 all wound at TN 3+, but Bulwark blocks any roll < 5
+    expect(result.playerResult.wounds).toBe(1);
+    expect(result.playerResult.unsavedWounds).toBe(1);
+    expect(result.updatedState.ai.isCasualty).toBe(false);
+    expect(result.updatedState.ai.currentWounds).toBe(5); // W6 − 1 damage = 5
+  });
+
+  it('Bulwark of the Imperium: overrides Poisoned(2+) special rule', () => {
+    // S1 vs T6 = 6+ normally; Poisoned(2+) lowers effective TN to 2+.
+    // Bulwark still blocks rolls < 5, so rolls 2,3,4 fail despite Poisoned(2+).
+    // Without Bulwark all four rolls (2,3,4,5) would wound; with Bulwark only roll 5 passes.
+    const attacker: Character = {
+      ...WARBOSS,
+      id: 'bulwark-poison-attacker',
+      stats: { ...WARBOSS.stats, WS: 7, S: 1, A: 3, W: 4, Inv: null },
+      specialRules: [],
+    };
+    const poisonedWeapon = {
+      profileName: 'Bulwark Poison Weapon',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: 2, damage: 1,
+      specialRules: [{ name: 'Poisoned' as const, threshold: 2 }],
+    };
+    const state: CombatState = {
+      ...makeState(attacker, DORN),
+      challengeAdvantage: 'player',
+      player: {
+        ...makeState(attacker, DORN).player,
+        selectedWeaponProfile: poisonedWeapon,
+      },
+      ai: {
+        ...makeState(attacker, DORN).ai,
+        selectedGambit: 'bulwark-of-the-imperium',
+        selectedWeaponProfile: DORN.weapons[0].profiles[0],
+      },
+    };
+    const dice = new FakeDiceRoller([
+      5, 5, 5, 5,   // 4 hit rolls (TN 4+, all hit)
+      2, 3, 4, 5,   // 4 wound rolls: Poisoned gives TN 2+, Bulwark still blocks 2,3,4
+      1,            // 1 save roll (AP2 → Inv4+, fail)
+      1,1,1,1,1,1,  // 6 DORN hit rolls (all miss)
+    ]);
+    const result = resolveStrikeStep(dice, state, attacker, DORN, 'player');
+    expect(result.playerResult.wounds).toBe(1);
+    expect(result.playerResult.unsavedWounds).toBe(1);
+  });
+
+  it('Bulwark of the Imperium: Critical Hits auto-wound, bypassing the wound-roll check', () => {
+    // CriticalHit(2+): every hit (TN 4+) rolls ≥ 4 ≥ 2 → Critical Hit → auto-wound.
+    // Auto-wounds bypass the wound-roll test entirely, so Bulwark cannot block them.
+    // critDmg = D1+1=2; EW2 → max(1,2−2)=1 per wound. 4×1=4 total damage. DORN W6−4=2.
+    const attacker: Character = {
+      ...WARBOSS,
+      id: 'bulwark-crit-attacker',
+      stats: { ...WARBOSS.stats, WS: 7, S: 4, A: 3, W: 4, Inv: null },
+      specialRules: [],
+    };
+    const critWeapon = {
+      profileName: 'Bulwark Crit Weapon',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: 2, damage: 1,
+      specialRules: [{ name: 'CriticalHit' as const, threshold: 2 }],
+    };
+    const state: CombatState = {
+      ...makeState(attacker, DORN),
+      challengeAdvantage: 'player',
+      player: {
+        ...makeState(attacker, DORN).player,
+        selectedWeaponProfile: critWeapon,
+      },
+      ai: {
+        ...makeState(attacker, DORN).ai,
+        selectedGambit: 'bulwark-of-the-imperium',
+        selectedWeaponProfile: DORN.weapons[0].profiles[0],
+      },
+    };
+    const dice = new FakeDiceRoller([
+      5, 5, 5, 5,   // 4 hit rolls (≥ 4+ hit; ≥ 2+ crit → all 4 Critical Hits → auto-wound)
+      // no wound dice — all hits are Critical Hits
+      1, 1, 1, 1,   // 4 save rolls (AP2 → Inv4+, all fail) → 4 unsaved crit wounds
+      1,1,1,1,1,1,  // 6 DORN hit rolls (all miss)
+    ]);
+    const result = resolveStrikeStep(dice, state, attacker, DORN, 'player');
+    // All 4 crits auto-wound even with Bulwark active (no wound roll = no roll to block)
+    expect(result.playerResult.wounds).toBe(4);
+    expect(result.playerResult.unsavedWounds).toBe(4);
+    expect(result.updatedState.ai.isCasualty).toBe(false);
+    expect(result.updatedState.ai.currentWounds).toBe(2); // W6 − 4 damage = 2
   });
 
   it('Mirror-Form: hits always on 4+ regardless of WS comparison', () => {

--- a/src/engine/gambitEffects.ts
+++ b/src/engine/gambitEffects.ts
@@ -253,6 +253,14 @@ export interface StrikeModifiers {
    * Number of self-wounds is tracked separately via dutyIsSacrificeWounds.
    */
   dutyIsSacrificeWounds: number;
+  /**
+   * If not null, unmodified Wound Test dice results strictly below this value
+   * always fail, regardless of Strength, Toughness comparisons, or any Special
+   * Rules that set the Target Number for Wound Tests (e.g. Poisoned).
+   * Set on the *defender's* gambit modifiers (Bulwark of the Imperium: value 5).
+   * Critical hits, which auto-wound without a dice roll, are unaffected.
+   */
+  minimumWoundRoll: number | null;
 }
 
 /**
@@ -285,6 +293,7 @@ export function getStrikeModifiers(
     overrideDefenderToughness: null,
     phageToughness: false,
     dutyIsSacrificeWounds: 0,
+    minimumWoundRoll: null,
   };
 
   const attacker = forPlayer ? state.player : state.ai;
@@ -367,6 +376,15 @@ export function getStrikeModifiers(
       return {
         ...base,
         criticalHitThreshold: 6,
+      };
+
+    case 'bulwark-of-the-imperium':
+      // Wound rolls of 1-4 against this model always fail.
+      // Set on the *defender's* modifiers; read by the attack engine in
+      // strikeStep.ts after all other wound TN logic is resolved.
+      return {
+        ...base,
+        minimumWoundRoll: 5,
       };
 
     // ── Blood Angels ────────────────────────────────────────────────────────

--- a/src/engine/strikeStep.ts
+++ b/src/engine/strikeStep.ts
@@ -238,6 +238,11 @@ function resolveAttackSequence(
       // Rending: high hit roll auto-wounds (approximated on wound roll here)
       if (sr.name === 'Rending' && roll >= sr.threshold) isWound = true;
     }
+    // Bulwark of the Imperium: unmodified wound rolls below the minimum always fail,
+    // regardless of Strength, Toughness comparisons, Poisoned, or Rending.
+    if (defenderMods.minimumWoundRoll !== null && roll < defenderMods.minimumWoundRoll) {
+      isWound = false;
+    }
     if (isWound) {
       normalWounds++;
       if (mods.phageToughness) currentDefT = Math.max(1, currentDefT - 1);

--- a/src/models/gambit.ts
+++ b/src/models/gambit.ts
@@ -36,6 +36,7 @@ export type GambitId =
   | 'a-wall-unyielding'       // all IF: no CI contribution to Focus, gain EternalWarrior(1)
   | 'deaths-champion'         // Sigismund: attacks gain CriticalHit(5+)
   | 'executioners-tax'        // Fafnir Rann: roll 2d6 discard highest, attacks gain CriticalHit(6+)
+  | 'bulwark-of-the-imperium' // Rogal Dorn: wound rolls of 1-4 against this model always fail
   // ── Blood Angels (IX) ────────────────────────────────────────────────────
   | 'thrall-of-the-red-thirst'// all BA: ignore wound penalties, +1 Damage, no OS bonus
   | 'angelic-descent'         // Sanguinius: +Focus bonus equal to enemy Bulky(X)


### PR DESCRIPTION
Wound Tests against Rogal Dorn with an unmodified result of 1-4 always fail, regardless of Strength, Toughness comparisons, or Special Rules that set the Target Number (e.g. Poisoned). Critical Hits, which auto-wound without a dice roll, are unaffected.

- Add `minimumWoundRoll` field to StrikeModifiers (defender-side)
- Apply Bulwark check in wound loop after Rending, overriding all other wound TN logic
- Add gambit definition to IMPERIAL_FISTS_GAMBITS
- Add 'bulwark-of-the-imperium' to Rogal Dorn's factionGambitIds
- Add 3 tests covering: basic S vs T override, Poisoned override, and Critical Hit bypass (95 tests passing)