### PR TITLE
Add Sublime Swordsman special rule for Fulgrim

### DIFF
--- a/src/data/factions/traitorLegions.ts
+++ b/src/data/factions/traitorLegions.ts
@@ -68,6 +68,7 @@ const FULGRIM: Character = {
   specialRules: [
     { name: 'EternalWarrior', value: 2 },
     { name: 'Bulky', value: 4 },
+    { name: 'SublimeSwordsman' },
   ],
 };
 

--- a/src/engine/__tests__/strikeStep.test.ts
+++ b/src/engine/__tests__/strikeStep.test.ts
@@ -17,6 +17,7 @@ const EVERSOR = ASSASSIN_CHARACTERS.find(c => c.id === 'eversor-assassin')!;
 const ADAMUS  = ASSASSIN_CHARACTERS.find(c => c.id === 'adamus-assassin')!;
 const DORN      = LOYALIST_LEGION_CHARACTERS.find(c => c.id === 'rogal-dorn')!;
 const MORTARION = TRAITOR_LEGION_CHARACTERS.find(c => c.id === 'mortarion')!;
+const FULGRIM   = TRAITOR_LEGION_CHARACTERS.find(c => c.id === 'fulgrim')!;
 
 function makeState(
   playerChar = VALDOR,
@@ -641,6 +642,95 @@ describe('resolveStrikeStep', () => {
     expect(result.playerResult.wounds).toBe(1);
     expect(result.playerResult.unsavedWounds).toBe(1);
     expect(result.updatedState.ai.currentWounds).toBe(6); // W7 − 1 = 6
+  });
+
+  it('Sublime Swordsman: +1A per point I exceeds opponent\'s I when having advantage', () => {
+    // Fulgrim: I=8, A=6. Opponent I=4 → I diff = 4 → +4 Attacks via Sublime Swordsman.
+    // With advantage: total = A6 + 1 (advantage) + 4 (I diff) = 11 attacks.
+    // All hit rolls of 1 → miss (WS8 vs WS4 = 2+; roll 1 < 2). AI misses back.
+    const opponent: Character = {
+      ...WARBOSS,
+      id: 'sublime-test-opponent',
+      stats: { ...WARBOSS.stats, WS: 4, I: 4, A: 2, Inv: null },
+      specialRules: [],
+    };
+    const state: CombatState = {
+      ...makeState(FULGRIM, opponent),
+      challengeAdvantage: 'player',
+      player: {
+        ...makeState(FULGRIM, opponent).player,
+        selectedWeaponProfile: FULGRIM.weapons[0].profiles[0],
+      },
+      ai: {
+        ...makeState(FULGRIM, opponent).ai,
+        selectedWeaponProfile: opponent.weapons[0].profiles[0],
+      },
+    };
+    const dice = new FakeDiceRoller([
+      1,1,1,1,1,1,1,1,1,1,1, // 11 Fulgrim hit rolls (A6 + 1 advantage + 4 I-diff = 11; all miss)
+      1,1,                    // 2 opponent hit rolls (A2, no advantage bonus; all miss)
+    ]);
+    const result = resolveStrikeStep(dice, state, FULGRIM, opponent, 'player');
+    expect(result.playerResult.attacks).toBe(11);
+  });
+
+  it('Sublime Swordsman: no bonus when this model does NOT have Challenge Advantage', () => {
+    // Fulgrim attacks second (AI has advantage). No Sublime Swordsman bonus.
+    // Fulgrim total = A6 + 0 (no advantage) + 0 (no Sublime Swordsman) = 6 attacks.
+    // Opponent: A2 + 1 advantage = 3 attacks, WS4 vs Fulgrim WS8 → TN 6+, all miss.
+    const opponent: Character = {
+      ...WARBOSS,
+      id: 'sublime-test-opponent-2',
+      stats: { ...WARBOSS.stats, WS: 4, I: 4, A: 2, Inv: null },
+      specialRules: [],
+    };
+    const state: CombatState = {
+      ...makeState(FULGRIM, opponent),
+      challengeAdvantage: 'ai',
+      player: {
+        ...makeState(FULGRIM, opponent).player,
+        selectedWeaponProfile: FULGRIM.weapons[0].profiles[0],
+      },
+      ai: {
+        ...makeState(FULGRIM, opponent).ai,
+        selectedWeaponProfile: opponent.weapons[0].profiles[0],
+      },
+    };
+    const dice = new FakeDiceRoller([
+      1,1,1,          // 3 opponent hit rolls (A2 + 1 advantage = 3; TN 6+, all miss)
+      1,1,1,1,1,1,    // 6 Fulgrim hit rolls (A6, no bonus; TN 2+, all miss on 1)
+    ]);
+    const result = resolveStrikeStep(dice, state, FULGRIM, opponent, 'ai');
+    expect(result.playerResult.attacks).toBe(6);
+  });
+
+  it('Sublime Swordsman: no bonus when opponent I equals or exceeds Fulgrim\'s I', () => {
+    // Opponent I=8 (same as Fulgrim I=8): diff = 0 → no Sublime Swordsman bonus.
+    // Fulgrim total = A6 + 1 (advantage) + 0 = 7 attacks.
+    const opponent: Character = {
+      ...WARBOSS,
+      id: 'sublime-test-high-i',
+      stats: { ...WARBOSS.stats, WS: 4, I: 8, A: 2, Inv: null },
+      specialRules: [],
+    };
+    const state: CombatState = {
+      ...makeState(FULGRIM, opponent),
+      challengeAdvantage: 'player',
+      player: {
+        ...makeState(FULGRIM, opponent).player,
+        selectedWeaponProfile: FULGRIM.weapons[0].profiles[0],
+      },
+      ai: {
+        ...makeState(FULGRIM, opponent).ai,
+        selectedWeaponProfile: opponent.weapons[0].profiles[0],
+      },
+    };
+    const dice = new FakeDiceRoller([
+      1,1,1,1,1,1,1, // 7 Fulgrim hit rolls (A6 + 1 advantage + 0 I-diff = 7; all miss)
+      1,1,           // 2 opponent hit rolls (A2, no advantage; all miss)
+    ]);
+    const result = resolveStrikeStep(dice, state, FULGRIM, opponent, 'player');
+    expect(result.playerResult.attacks).toBe(7);
   });
 
   it('Mirror-Form: hits always on 4+ regardless of WS comparison', () => {

--- a/src/engine/strikeStep.ts
+++ b/src/engine/strikeStep.ts
@@ -116,6 +116,21 @@ function resolveAttackSequence(
   // Minimum 1 attack
   atkA = Math.max(1, atkA + attackBonus);
 
+  // Sublime Swordsman: +1A per point this model's Base I exceeds the opponent's,
+  // but only when this model has Challenge Advantage (attackBonus > 0).
+  if (attackBonus > 0) {
+    const hasSublimeSwordsman = attackerChar.specialRules.some(
+      sr => sr.name === 'SublimeSwordsman',
+    );
+    if (hasSublimeSwordsman) {
+      const iBonus = Math.max(0, attackerChar.stats.I - defenderChar.stats.I);
+      if (iBonus > 0) {
+        log.push(`Sublime Swordsman: +${iBonus} Attacks (I${attackerChar.stats.I} vs I${defenderChar.stats.I})`);
+        atkA += iBonus;
+      }
+    }
+  }
+
   // Single-attack cap (Guard Up / Withdraw)
   if (mods.singleAttackCap) atkA = 1;
 

--- a/src/models/weapon.ts
+++ b/src/models/weapon.ts
@@ -38,7 +38,8 @@ export type SpecialRule =
   | { name: 'Bulky';            value: number }       // counts as X models; used by Angelic Descent
   | { name: 'FeelNoPain';       threshold: number }  // ignore unsaved wound on roll ≥ threshold
   | { name: 'Poisoned';         threshold: number }   // wound always on roll ≥ threshold (ignores S vs T comparison)
-  | { name: 'PraeternaturalResilience' };             // CriticalHit(X) attacks against this model use X=6 (raises threshold to 6+)
+  | { name: 'PraeternaturalResilience' }              // CriticalHit(X) attacks against this model use X=6 (raises threshold to 6+)
+  | { name: 'SublimeSwordsman' };                     // +1A per point this model's Base I exceeds opponent's, when this model has Challenge Advantage
   // Rules intentionally not simulated:
   //   Force(D)   — Force staff psychic instakill; too complex for Challenge scope
   //   Bypass(X+) — Phase sword's bypass of all saves; omitted (no Bypass special rule added)


### PR DESCRIPTION
While Fulgrim has Challenge Advantage, his Attacks Characteristic gains +1 for each point his Base Initiative exceeds his opponent's Base Initiative. The bonus is applied after the advantage +1 but before the single-attack cap (Guard Up / Withdraw still overrides it).

- Add SublimeSwordsman to SpecialRule union in weapon.ts
- Add { name: 'SublimeSwordsman' } to Fulgrim's specialRules
- Compute bonus in resolveAttackSequence when attackBonus > 0: atkA += Math.max(0, attackerChar.stats.I - defenderChar.stats.I)
- Add 3 tests: with advantage (I diff +4 → 11 attacks), without advantage (6 attacks), equal I (7 attacks) — 100 tests passing