### PR TITLE
feat: implement Battle of the Wills gambit for Magnus the Red

### DIFF
--- a/src/data/factions/traitorLegions.ts
+++ b/src/data/factions/traitorLegions.ts
@@ -250,9 +250,7 @@ const MAGNUS_THE_RED: Character = {
     Sv: 2, Inv: 4,
   },
   weapons: [BLADE_OF_AHN_NUNURTA],
-  // Battle of the Wills is a passive always-on Focus bonus (not a selectable gambit).
-  // It is handled in focusStep.ts by checking the character's specialRules.
-  factionGambitIds: ['prophetic-duellist'],
+  factionGambitIds: ['battle-of-the-wills', 'prophetic-duellist'],
   specialRules: [
     { name: 'EternalWarrior', value: 2 },
     { name: 'Bulky', value: 5 },

--- a/src/data/gambits/traitorLegions.ts
+++ b/src/data/gambits/traitorLegions.ts
@@ -110,6 +110,14 @@ export const DEATH_GUARD_GAMBITS: Gambit[] = [
 
 export const THOUSAND_SONS_GAMBITS: Gambit[] = [
   {
+    id: 'battle-of-the-wills',
+    name: 'Battle of the Wills',
+    description: 'Gain a positive modifier to the Focus Roll equal to this model\'s Base Willpower Characteristic minus the Base Willpower Characteristic of the opposing model. If the result is 0 or negative, no modifier is gained.',
+    timings: ['focus'],
+    firstMoverOnly: false,
+    oncePerChallenge: false,
+  },
+  {
     id: 'prophetic-duellist',
     name: 'Prophetic Duellist',
     description: 'Immediately after making the Focus Roll, the controlling player may choose to replace the result (after all modifiers) with this model\'s Willpower Characteristic.',

--- a/src/engine/__tests__/focusStep.test.ts
+++ b/src/engine/__tests__/focusStep.test.ts
@@ -3,12 +3,14 @@ import { resolveFocusStep } from '../focusStep.js';
 import { FakeDiceRoller } from '../dice.js';
 import { CUSTODES_CHARACTERS } from '../../data/factions/custodes.js';
 import { ORK_CHARACTERS } from '../../data/factions/orks.js';
+import { TRAITOR_LEGION_CHARACTERS } from '../../data/factions/traitorLegions.js';
 import { buildInitialState } from '../challengeEngine.js';
 
 const VALDOR     = CUSTODES_CHARACTERS.find(c => c.id === 'constantin-valdor')!;
 const TRIBUNE    = CUSTODES_CHARACTERS.find(c => c.id === 'tribune')!;
 const WARBOSS    = ORK_CHARACTERS.find(c => c.id === 'warboss-goffs')!;
 const MEGA_BOSS  = ORK_CHARACTERS.find(c => c.id === 'mega-warboss')!;
+const MAGNUS     = TRAITOR_LEGION_CHARACTERS.find(c => c.id === 'magnus-the-red')!;
 
 function makeState(playerChar = VALDOR, aiChar = WARBOSS) {
   const s = buildInitialState(playerChar, aiChar);
@@ -118,6 +120,44 @@ describe('resolveFocusStep', () => {
     const result = resolveFocusStep(dice, state, VALDOR, WARBOSS, null);
     // Player total = 1 + CI(6) + DE(2) + guardUp(2) = 11; AI = 6 + CI(4) = 10
     expect(result.playerRoll.total).toBe(11);
+    expect(result.advantage).toBe('player');
+  });
+
+  it('Battle of the Wills: adds WP difference as flat Focus bonus', () => {
+    // Magnus WP=10 vs WARBOSS WP=9 → flatBonus = max(0, 10−9) = +1
+    // Magnus CI = I(6) + no I modifier = 6; DE = 0 (Blade of Ahn-nunurta has no DuellistsEdge)
+    // Dice: player rolls 4, AI rolls 1
+    // Magnus total = 4 + CI(6) + bonus(1) = 11; WARBOSS total = 1 + CI(4) = 5
+    const dice = new FakeDiceRoller([4, 1]);
+    const state = {
+      ...makeState(MAGNUS, WARBOSS),
+      player: {
+        ...makeState(MAGNUS, WARBOSS).player,
+        selectedGambit: 'battle-of-the-wills' as any,
+      },
+    };
+    const result = resolveFocusStep(dice, state, MAGNUS, WARBOSS, null);
+    expect(result.playerRoll.total).toBe(11);
+    expect(result.playerRoll.modifiers).toBe(1); // WP bonus only, no DE
+    expect(result.advantage).toBe('player');
+  });
+
+  it('Battle of the Wills: no bonus when WP difference is zero or negative', () => {
+    // Magnus WP=10 vs opponent with WP=10 → flatBonus = max(0, 10−10) = 0
+    // Dice: player rolls 4, AI rolls 1
+    // Magnus total = 4 + CI(6) + 0 = 10
+    const opponentWP10 = { ...WARBOSS, stats: { ...WARBOSS.stats, WP: 10 } };
+    const dice = new FakeDiceRoller([4, 1]);
+    const state = {
+      ...makeState(MAGNUS, opponentWP10),
+      player: {
+        ...makeState(MAGNUS, opponentWP10).player,
+        selectedGambit: 'battle-of-the-wills' as any,
+      },
+    };
+    const result = resolveFocusStep(dice, state, MAGNUS, opponentWP10, null);
+    expect(result.playerRoll.total).toBe(10);
+    expect(result.playerRoll.modifiers).toBe(0); // no bonus
     expect(result.advantage).toBe('player');
   });
 });

--- a/src/engine/focusStep.ts
+++ b/src/engine/focusStep.ts
@@ -184,6 +184,7 @@ export function resolveFocusStep(
     currentWounds:   state.player.currentWounds,
     baseWounds:      state.player.baseWounds,
     ownWP:           playerChar.stats.WP,
+    enemyWP:         aiChar.stats.WP,
     enemyBulkyValue: getBulkyValue(aiChar),
     characterId:     playerChar.id,
   };
@@ -192,6 +193,7 @@ export function resolveFocusStep(
     currentWounds:   state.ai.currentWounds,
     baseWounds:      state.ai.baseWounds,
     ownWP:           aiChar.stats.WP,
+    enemyWP:         playerChar.stats.WP,
     enemyBulkyValue: getBulkyValue(playerChar),
     characterId:     aiChar.id,
   };

--- a/src/engine/gambitEffects.ts
+++ b/src/engine/gambitEffects.ts
@@ -67,6 +67,8 @@ export interface FocusContext {
   baseWounds?: number;
   /** Willpower of the gambit user (used by Prophetic Duellist). */
   ownWP?: number;
+  /** Willpower of the opposing model (used by Battle of the Wills). */
+  enemyWP?: number;
   /** Enemy model's Bulky(X) value (used by Angelic Descent). */
   enemyBulkyValue?: number;
   /** Character ID of the gambit user (for Lucius/Paragon of Excellence). */
@@ -99,6 +101,8 @@ export function getFocusDiceModification(
   const currentWounds   = ctx.currentWounds  ?? 99;
   const enemyBulkyValue = ctx.enemyBulkyValue ?? 0;
   const characterId     = ctx.characterId    ?? '';
+  const ownWP           = ctx.ownWP          ?? 0;
+  const enemyWP         = ctx.enemyWP        ?? 0;
 
   switch (gambitId) {
     // ── Core gambits ────────────────────────────────────────────────────────
@@ -186,6 +190,10 @@ export function getFocusDiceModification(
     }
 
     // ── Thousand Sons ───────────────────────────────────────────────────────
+    case 'battle-of-the-wills':
+      // +Focus equal to max(0, own WP − opponent WP).
+      return { ...base, flatBonus: Math.max(0, ownWP - enemyWP) };
+
     case 'prophetic-duellist':
       // After roll, may replace total with own WP.
       return { ...base, replaceWithWP: true };
@@ -205,7 +213,7 @@ export function getFocusDiceModification(
   }
 
   // Suppress TS unused-variable warnings (variables captured in switch cases above)
-  void round; void currentWounds; void enemyBulkyValue;
+  void round; void currentWounds; void enemyBulkyValue; void ownWP; void enemyWP;
 }
 
 // ─── Strike step modifiers ────────────────────────────────────────────────────

--- a/src/models/gambit.ts
+++ b/src/models/gambit.ts
@@ -67,6 +67,7 @@ export type GambitId =
   | 'steadfast-resilience'    // all DG: T = opponent's WS for Strike Step
   | 'witchblood'              // Calas Typhon: once/battle; WP check → +2A/+2S or 1 wound
   // ── Thousand Sons (XV) ───────────────────────────────────────────────────
+  | 'battle-of-the-wills'    // Magnus the Red: +Focus equal to max(0, own WP − opponent WP)
   | 'prophetic-duellist'      // all TS: after Focus Roll, may replace total with own WP
   // ── Sons of Horus (XVI) ──────────────────────────────────────────────────
   | 'merciless-strike'        // all SoH: first round only; weapons gain Phage(T) (reduce enemy T per wound)


### PR DESCRIPTION
Add Focus Roll modifier equal to max(0, own WP − opponent WP), giving Magnus (WP 10) a +1 Focus bonus when facing most opponents. Adds enemyWP to FocusContext so the gambit case can compare both sides.