### PR TITLE
feat: implement Psychic Discipline support for Legion Astartes Librar…

### DIFF
--- a/src/data/factions/legionAstartes.ts
+++ b/src/data/factions/legionAstartes.ts
@@ -146,7 +146,7 @@ const CHAPLAIN: Character = {
 // Legion Psyker in Cataphractii Terminator armour.  WP9 makes the Force weapon
 // WP check very reliable.  Heavy sub-type imposes −1 to Focus Rolls.
 // Implacable Advance and Slow and Purposeful are movement/shooting rules with
-// no effect in the Challenge Sub-Phase.  Psyker trait has no engine effect.
+// no effect in the Challenge Sub-Phase.
 const CATAPHRACTII_LIBRARIAN: Character = {
   id: 'cataphractii-librarian',
   name: 'Cataphractii Librarian',
@@ -160,7 +160,8 @@ const CATAPHRACTII_LIBRARIAN: Character = {
   },
   weapons: [FORCE_SWORD, FORCE_AXE, FORCE_MAUL, FORCE_STAFF],
   factionGambitIds: [],
-  specialRules: [{ name: 'Bulky', value: 2 }],
+  specialRules: [{ name: 'Bulky', value: 2 }, { name: 'Psyker' }],
+  availablePsychicDisciplines: ['biomancy', 'pyromancy', 'telekinesis', 'divination', 'thaumaturgy'],
 };
 
 // ── Tartaros Librarian ────────────────────────────────────────────────────────
@@ -179,7 +180,8 @@ const TARTAROS_LIBRARIAN: Character = {
   },
   weapons: [FORCE_SWORD, FORCE_AXE, FORCE_MAUL, FORCE_STAFF],
   factionGambitIds: [],
-  specialRules: [{ name: 'Bulky', value: 2 }],
+  specialRules: [{ name: 'Bulky', value: 2 }, { name: 'Psyker' }],
+  availablePsychicDisciplines: ['biomancy', 'pyromancy', 'telekinesis', 'divination', 'thaumaturgy'],
 };
 
 // ── Librarian (Jump Pack) ─────────────────────────────────────────────────────
@@ -198,7 +200,8 @@ const LIBRARIAN_JUMP_PACK: Character = {
   },
   weapons: [FORCE_SWORD, FORCE_AXE, FORCE_MAUL, FORCE_STAFF],
   factionGambitIds: [],
-  specialRules: [{ name: 'Bulky', value: 2 }],
+  specialRules: [{ name: 'Bulky', value: 2 }, { name: 'Psyker' }],
+  availablePsychicDisciplines: ['biomancy', 'pyromancy', 'telekinesis', 'divination', 'thaumaturgy'],
 };
 
 // ── Centurion ─────────────────────────────────────────────────────────────────
@@ -270,8 +273,8 @@ const LIBRARIAN: Character = {
   },
   weapons: [FORCE_SWORD, FORCE_AXE, FORCE_STAFF, FORCE_MAUL],
   factionGambitIds: [],
-  specialRules: [],
-
+  specialRules: [{ name: 'Psyker' }],
+  availablePsychicDisciplines: ['biomancy', 'pyromancy', 'telekinesis', 'divination', 'thaumaturgy'],
 };
 
 // ── Chosen Champion ──────────────────────────────────────────────────────────

--- a/src/data/gambits/loyalistLegions.ts
+++ b/src/data/gambits/loyalistLegions.ts
@@ -222,6 +222,19 @@ export const RAVEN_GUARD_GAMBITS: Gambit[] = [
   },
 ];
 
+// ── Legion Astartes Psychic Discipline gambits ────────────────────────────────
+
+export const LEGION_ASTARTES_PSYCHIC_GAMBITS: Gambit[] = [
+  {
+    id: 'divination-every-strike-foreseen',
+    name: 'Every Strike Foreseen',
+    description: 'Divination: make a Willpower check (2d6 ≤ WP, no Perils). If successful, all Hit Tests for this model succeed on a roll of 2+ this Strike Step.',
+    timings: ['strike'],
+    firstMoverOnly: false,
+    oncePerChallenge: false,
+  },
+];
+
 // ── Combined export ──────────────────────────────────────────────────────────
 
 export const LOYALIST_LEGION_GAMBITS: Gambit[] = [
@@ -234,4 +247,5 @@ export const LOYALIST_LEGION_GAMBITS: Gambit[] = [
   ...ULTRAMARINES_GAMBITS,
   ...SALAMANDERS_GAMBITS,
   ...RAVEN_GUARD_GAMBITS,
+  ...LEGION_ASTARTES_PSYCHIC_GAMBITS,
 ];

--- a/src/data/psychicDisciplines.ts
+++ b/src/data/psychicDisciplines.ts
@@ -1,0 +1,76 @@
+/**
+ * Psychic Discipline configuration for Legion Astartes Librarian characters.
+ *
+ * Each discipline may grant:
+ *   - A melee Psychic Weapon
+ *   - Character-level Special Rules
+ *   - Faction Gambit IDs
+ *
+ * Applying a discipline returns a shallow-cloned Character with the discipline's
+ * weapons, rules, and gambits merged in.
+ */
+import type { Character, PsychicDiscipline } from '../models/character.js';
+import type { Weapon, SpecialRule } from '../models/weapon.js';
+import type { GambitId } from '../models/gambit.js';
+import { BIOMANTIC_SLAM } from './weapons/psychic.js';
+import { CONFLAGRATION }  from './weapons/psychic.js';
+
+export interface DisciplineConfig {
+  name: string;
+  meleeWeapon?: Weapon;
+  specialRules: SpecialRule[];
+  gambitIds: GambitId[];
+}
+
+export const DISCIPLINE_CONFIGS: Record<PsychicDiscipline, DisciplineConfig> = {
+  biomancy: {
+    name: 'Biomancy',
+    meleeWeapon: BIOMANTIC_SLAM,
+    specialRules: [],
+    gambitIds: [],
+  },
+  pyromancy: {
+    name: 'Pyromancy',
+    meleeWeapon: CONFLAGRATION,
+    specialRules: [],
+    gambitIds: [],
+  },
+  telekinesis: {
+    name: 'Telekinesis',
+    // All powers are Ranged/Reaction — no melee weapon, no challenge effects
+    specialRules: [],
+    gambitIds: [],
+  },
+  divination: {
+    name: 'Divination',
+    specialRules: [{ name: 'DuellistsEdge', value: 2 }],
+    gambitIds: ['divination-every-strike-foreseen'],
+  },
+  thaumaturgy: {
+    name: 'Thaumaturgy',
+    specialRules: [{ name: 'Hatred', target: 'Psykers' }],
+    gambitIds: [],
+  },
+};
+
+/**
+ * Return a shallow-cloned Character with the chosen discipline's weapons,
+ * special rules, and gambit IDs merged in.
+ *
+ * The discipline weapon (if any) is appended to the end of the weapons array
+ * so that existing weapon indices remain unchanged.
+ */
+export function applyDiscipline(char: Character, discipline: PsychicDiscipline): Character {
+  const config = DISCIPLINE_CONFIGS[discipline];
+  const weapons = config.meleeWeapon
+    ? [...char.weapons, config.meleeWeapon]
+    : char.weapons;
+  const specialRules = config.specialRules.length
+    ? [...char.specialRules, ...config.specialRules]
+    : char.specialRules;
+  const factionGambitIds = config.gambitIds.length
+    ? [...char.factionGambitIds, ...config.gambitIds]
+    : char.factionGambitIds;
+
+  return { ...char, weapons, specialRules, factionGambitIds };
+}

--- a/src/data/weapons/psychic.ts
+++ b/src/data/weapons/psychic.ts
@@ -1,0 +1,58 @@
+/**
+ * Psychic melee weapon profiles for Legion Astartes Librarian disciplines.
+ *
+ * These weapons are granted by specialising in a Psychic Discipline and are
+ * not available to Librarians without a discipline selected.
+ *
+ * Biomancy   → Biomantic Slam
+ * Pyromancy  → Conflagration
+ */
+import type { Weapon } from '../../models/weapon.js';
+
+/**
+ * Biomantic Slam (Biomancy)
+ * IM -3, AM +1, S 12 (fixed), AP 2, D 2
+ * Special rules: Armourbane, Force(D)
+ */
+export const BIOMANTIC_SLAM: Weapon = {
+  name: 'Biomantic Slam',
+  type: 'melee',
+  profiles: [
+    {
+      profileName: 'Biomantic Slam',
+      initiativeModifier: { kind: 'add',   value: -3 },
+      attacksModifier:    { kind: 'add',   value: 1  },
+      strengthModifier:   { kind: 'fixed', value: 12 },
+      ap: 2,
+      damage: 2,
+      specialRules: [
+        { name: 'Armourbane' },
+        { name: 'Force', characteristic: 'D' },
+      ],
+    },
+  ],
+};
+
+/**
+ * Conflagration (Pyromancy)
+ * IM -1, AM 6+D3 (fixed 6, plus D3 via attacksExtraD3), S 5 (fixed), AP 4, D 1
+ * Special rules: Deflagrate(5)
+ */
+export const CONFLAGRATION: Weapon = {
+  name: 'Conflagration',
+  type: 'melee',
+  profiles: [
+    {
+      profileName: 'Conflagration',
+      initiativeModifier: { kind: 'add',   value: -1 },
+      attacksModifier:    { kind: 'fixed', value: 6  },
+      strengthModifier:   { kind: 'fixed', value: 5  },
+      ap: 4,
+      damage: 1,
+      attacksExtraD3: true,
+      specialRules: [
+        { name: 'Deflagrate', value: 5 },
+      ],
+    },
+  ],
+};

--- a/src/engine/__tests__/strikeStep.test.ts
+++ b/src/engine/__tests__/strikeStep.test.ts
@@ -952,3 +952,260 @@ describe('resolveStrikeStep', () => {
     expect(result.updatedState.player.currentWounds).toBe(2); // W3 − 1 Perils
   });
 });
+
+// ── Psychic Discipline mechanic tests ─────────────────────────────────────────
+
+describe('Psychic Discipline mechanics (Conflagration, Every Strike Foreseen, Hatred, Deflagrate)', () => {
+  // Shared inline weapon profiles
+  const conflagrationProfile = {
+    profileName: 'Conflagration',
+    initiativeModifier: { kind: 'add'   as const, value: -1 },
+    attacksModifier:    { kind: 'fixed' as const, value: 6  },
+    strengthModifier:   { kind: 'fixed' as const, value: 5  },
+    ap: 4 as number | null,
+    damage: 1,
+    attacksExtraD3: true as boolean | undefined,
+    specialRules: [{ name: 'Deflagrate' as const, value: 5 }],
+  };
+
+  const simpleMeleeProfile = {
+    profileName: 'Simple Weapon',
+    initiativeModifier: { kind: 'none' as const },
+    attacksModifier:    { kind: 'none' as const },
+    strengthModifier:   { kind: 'none' as const },
+    ap: 4 as number | null,
+    damage: 1,
+    specialRules: [] as typeof conflagrationProfile.specialRules,
+  };
+
+  // Librarian-like attacker: WS5, S4, A4, WP9, Sv2+, Inv5+
+  const makeLibrarian = (extra: Partial<Character> = {}): Character => ({
+    id: 'test-librarian',
+    name: 'Librarian',
+    faction: 'legion-astartes',
+    type: 'infantry',
+    subTypes: ['Command'],
+    stats: { M: 7, WS: 5, BS: 5, S: 4, T: 4, W: 3, I: 5, A: 4, LD: 8, CL: 7, WP: 9, IN: 8, Sv: 2, Inv: 5 },
+    weapons: [],
+    factionGambitIds: [],
+    specialRules: [],
+    ...extra,
+  });
+
+  // Dummy defender: WS2, T4, A4, W5, Sv7+ (no armour save), no Inv
+  const makeDummy = (extra: Partial<Character> = {}): Character => ({
+    id: 'test-dummy',
+    name: 'Dummy',
+    faction: 'legion-astartes',
+    type: 'infantry',
+    subTypes: ['Command'],
+    stats: { M: 7, WS: 2, BS: 5, S: 4, T: 4, W: 5, I: 5, A: 4, LD: 8, CL: 7, WP: 9, IN: 8, Sv: 7, Inv: null },
+    weapons: [],
+    factionGambitIds: [],
+    specialRules: [],
+    ...extra,
+  });
+
+  it('Conflagration: attack count = 6 + D3 + attackBonus (attacksExtraD3 flag)', () => {
+    // weaponD3 raw=1 → D3=1 (consumed FIRST). AM fixed=6 → baseA=7. +1 advantage → atkA=8.
+    // All 8 hit rolls miss (WS5 vs WS6 = 5+, roll 1s). AI 4 attacks also miss.
+    const lib   = makeLibrarian();
+    const dummy = makeDummy({ stats: { ...makeDummy().stats, WS: 6, A: 4 } });
+    const s = buildInitialState(lib, dummy);
+    const state: CombatState = {
+      ...s,
+      challengeAdvantage: 'player',
+      player: { ...s.player, selectedGambit: null, selectedWeaponProfile: conflagrationProfile },
+      ai:     { ...s.ai,     selectedGambit: null, selectedWeaponProfile: simpleMeleeProfile  },
+    };
+    const dice = new FakeDiceRoller([
+      1,              // weaponD3 raw=1 → D3=1 → baseA=6+1=7, atkA=8
+      1,1,1,1,1,1,1,1, // 8 hit rolls (WS5 vs WS6 = 5+; roll 1 < 5 → all miss)
+      // AI: WS6 vs WS5 (lib) = 3+ (HIT_TABLE[5][4]=3); 4 attacks, roll 1s
+      1,1,1,1,        // 4 AI hit rolls (all miss)
+    ]);
+    const result = resolveStrikeStep(dice, state, lib, dummy, 'player');
+    expect(result.playerResult.attacks).toBe(8);   // 6 (fixed AM) + 1 (D3) + 1 (advantage)
+    expect(result.playerResult.hits).toBe(0);       // all missed at TN 5+
+  });
+
+  it('Deflagrate: unsaved wounds generate additional S5/AP-/D1 hits', () => {
+    // Conflagration on dummy WS2 T4 W16 (Sv7+, Inv-):
+    // weaponD3 raw=1 → D3=1 → baseA=7, atkA=8 (with advantage).
+    // 8 hits (TN 2+), 8 wounds (S5 vs T4 = 3+), effectiveSave=null (AP4 vs Sv7).
+    // Pool 2: 8 save dice consumed (even with null save). deflagrateUnsavedCount=8.
+    // Main damage: 8 × D1 = 8. Defender W16 → W8 (not a casualty yet).
+    // Deflagrate(5): 8 extra hits at S5/T4=TN3+: all 8 wound; AP- best save=7+ (d6 max 6): all fail.
+    // Deflagrate damage: 8 × D1 = 8. W8 − 8 = 0 → casualty. AI does not attack.
+    const lib   = makeLibrarian();
+    const dummy = makeDummy({ stats: { ...makeDummy().stats, WS: 2, T: 4, W: 16, Sv: 7, Inv: null } });
+    const s = buildInitialState(lib, dummy);
+    const state: CombatState = {
+      ...s,
+      challengeAdvantage: 'player',
+      player: { ...s.player, selectedGambit: null, selectedWeaponProfile: conflagrationProfile },
+      ai:     { ...s.ai,     selectedGambit: null, selectedWeaponProfile: simpleMeleeProfile  },
+    };
+    const dice = new FakeDiceRoller([
+      1,                    // weaponD3 raw=1 → D3=1
+      2,2,2,2,2,2,2,2,     // 8 hit rolls (TN 2+, all hit)
+      3,3,3,3,3,3,3,3,     // 8 wound rolls (S5 vs T4 = 3+, all wound)
+      1,1,1,1,1,1,1,1,     // Pool 2: 8 save rolls consumed (effectiveSave=null)
+      3,3,3,3,3,3,3,3,     // Deflagrate: 8 wound rolls (S5 vs T4 = 3+, all wound)
+      1,1,1,1,1,1,1,1,     // Deflagrate: 8 save rolls (AP- best=Sv7; 1 < 7 → all fail)
+    ]);
+    const result = resolveStrikeStep(dice, state, lib, dummy, 'player');
+    expect(result.playerResult.totalDamage).toBe(16);  // 8 main + 8 deflagrate
+    expect(result.updatedState.ai.isCasualty).toBe(true);
+    expect(result.playerResult.log.some(l => l.includes('Deflagrate'))).toBe(true);
+  });
+
+  it('Every Strike Foreseen: WP check success → all hits on 2+', () => {
+    // Without ESF, WS5 vs WS8 = 5+ (hard to hit). ESF WP check [1,3]=4 ≤ WP9 → SUCCESS.
+    // hitTNOverride = 2. 5 attacks (A4 + 1 advantage), rolls of 5 ≥ 2 → all 5 hit.
+    // Wound: S4 vs T4 = 4+; rolls 4 → all 5 wound. AP3 vs Sv7 → penetrated, no inv → no save.
+    // Pool 2: 5 dice consumed. 5 × D1 = 5. W5 → 0 → casualty.
+    const lib   = makeLibrarian({ stats: { ...makeLibrarian().stats, WP: 9 } });
+    const dummy = makeDummy({ stats: { ...makeDummy().stats, WS: 8, T: 4, W: 5, Sv: 7, Inv: null } });
+    const s = buildInitialState(lib, dummy);
+    const esfProfile = {
+      profileName: 'Power Sword',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: 3 as number | null,
+      damage: 1,
+      specialRules: [] as typeof conflagrationProfile.specialRules,
+    };
+    const state: CombatState = {
+      ...s,
+      challengeAdvantage: 'player',
+      player: { ...s.player, selectedGambit: 'divination-every-strike-foreseen', selectedWeaponProfile: esfProfile },
+      ai:     { ...s.ai,     selectedGambit: null, selectedWeaponProfile: simpleMeleeProfile },
+    };
+    const dice = new FakeDiceRoller([
+      1, 3,           // ESF WP check [1+3=4] ≤ WP9 → SUCCESS → hitTN override = 2
+      5,5,5,5,5,      // 5 hit rolls (override TN 2+; 5 ≥ 2 → all hit)
+      4,4,4,4,4,      // 5 wound rolls (S4 vs T4 = TN 4+; 4 ≥ 4 → all wound)
+      1,1,1,1,1,      // Pool 2 save rolls (AP3 vs Sv7: penetrated, null save; consumed)
+    ]);
+    const result = resolveStrikeStep(dice, state, lib, dummy, 'player');
+    expect(result.playerResult.hits).toBe(5);     // all 5 hit at TN 2+ (override)
+    expect(result.playerResult.wounds).toBe(5);
+    expect(result.updatedState.ai.isCasualty).toBe(true);
+    const hitLogLine = result.playerResult.log.find(l => l.includes('needing 2+'));
+    expect(hitLogLine).toBeDefined();
+  });
+
+  it('Every Strike Foreseen: WP check failure → normal hit TN applies', () => {
+    // ESF WP check [5,6]=11 > WP9 → FAIL. Normal hitTN: WS5 vs WS8 = 5+.
+    // 5 attacks roll 4 → all miss (4 < 5+). AI 4 attacks also miss.
+    const lib   = makeLibrarian({ stats: { ...makeLibrarian().stats, WP: 9 } });
+    const dummy = makeDummy({ stats: { ...makeDummy().stats, WS: 8, T: 4, W: 5, Sv: 7, Inv: null } });
+    const s = buildInitialState(lib, dummy);
+    const esfProfile = {
+      profileName: 'Power Sword',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: 3 as number | null,
+      damage: 1,
+      specialRules: [] as typeof conflagrationProfile.specialRules,
+    };
+    const state: CombatState = {
+      ...s,
+      challengeAdvantage: 'player',
+      player: { ...s.player, selectedGambit: 'divination-every-strike-foreseen', selectedWeaponProfile: esfProfile },
+      ai:     { ...s.ai,     selectedGambit: null, selectedWeaponProfile: simpleMeleeProfile },
+    };
+    const dice = new FakeDiceRoller([
+      5, 6,           // ESF WP check [5+6=11] > WP9 → FAIL → normal TN
+      4,4,4,4,4,      // 5 hit rolls (normal TN 5+: WS5 vs WS8; 4 < 5 → all miss)
+      1,1,1,1,        // 4 AI hit rolls (WS2 vs WS5 = 6+; all miss)
+    ]);
+    const result = resolveStrikeStep(dice, state, lib, dummy, 'player');
+    expect(result.playerResult.hits).toBe(0);    // all missed at normal TN 5+
+    expect(result.playerResult.log.some(l => l.includes('normal hits'))).toBe(true);
+  });
+
+  it('Hatred(Psykers): wound TN reduced by 1 when defender has Psyker rule', () => {
+    // Attacker has Hatred(Psykers). Defender has Psyker rule.
+    // S4 vs T4 = normal TN 4+. Wound rolls of 3: 3 < 4 → fail without Hatred.
+    // With Hatred: TN = max(2, 4-1) = 3+. 3 ≥ 3 → all 5 wound.
+    // AP3 vs Sv7: penetrated; effectiveSave=null; Pool 2 saves consumed.
+    // 5 unsaved wounds × D1 = 5. Defender W5 → 0 → casualty.
+    const lib = makeLibrarian({
+      specialRules: [{ name: 'Hatred', target: 'Psykers' }],
+    });
+    const dummy = makeDummy({
+      stats: { ...makeDummy().stats, WS: 5, T: 4, W: 5, Sv: 7, Inv: null },
+      specialRules: [{ name: 'Psyker' }],
+    });
+    const powerSwordProfile = {
+      profileName: 'Power Sword',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: 3 as number | null,
+      damage: 1,
+      specialRules: [] as typeof conflagrationProfile.specialRules,
+    };
+    const s = buildInitialState(lib, dummy);
+    const state: CombatState = {
+      ...s,
+      challengeAdvantage: 'player',
+      player: { ...s.player, selectedGambit: null, selectedWeaponProfile: powerSwordProfile },
+      ai:     { ...s.ai,     selectedGambit: null, selectedWeaponProfile: simpleMeleeProfile },
+    };
+    // WS5 vs WS5 = TN 4+ (HIT_TABLE[4][4]=4). Hit rolls of 4 → all 5 hit.
+    // Wound rolls of 3: with Hatred TN=max(2,4-1)=3+ → all 5 wound; without TN 4+: 3 < 4 → fail.
+    const dice = new FakeDiceRoller([
+      4,4,4,4,4,    // 5 hit rolls (TN 4+, all hit)
+      3,3,3,3,3,    // 5 wound rolls (with Hatred TN 3+: all wound; without TN 4+: all fail)
+      1,1,1,1,1,    // Pool 2 save rolls (AP3 vs Sv7: penetrated → effectiveSave=null; consumed)
+    ]);
+    const result = resolveStrikeStep(dice, state, lib, dummy, 'player');
+    expect(result.playerResult.wounds).toBe(5);   // wound TN = 2+ due to Hatred
+    expect(result.playerResult.unsavedWounds).toBe(5);
+    expect(result.updatedState.ai.isCasualty).toBe(true);
+    expect(result.playerResult.log.some(l => l.includes('Hatred'))).toBe(true);
+  });
+
+  it('Hatred(Psykers): no wound bonus when defender lacks Psyker rule', () => {
+    // Same setup but defender has no Psyker rule.
+    // Wound rolls of 3: normal TN 4+ → 3 < 4 → all fail. No damage.
+    const lib = makeLibrarian({
+      specialRules: [{ name: 'Hatred', target: 'Psykers' }],
+    });
+    const dummy = makeDummy({
+      stats: { ...makeDummy().stats, WS: 5, T: 4, W: 5, Sv: 7, Inv: null },
+      specialRules: [], // NO Psyker rule
+    });
+    const powerSwordProfile = {
+      profileName: 'Power Sword',
+      initiativeModifier: { kind: 'none' as const },
+      attacksModifier:    { kind: 'none' as const },
+      strengthModifier:   { kind: 'none' as const },
+      ap: 3 as number | null,
+      damage: 1,
+      specialRules: [] as typeof conflagrationProfile.specialRules,
+    };
+    const s = buildInitialState(lib, dummy);
+    const state: CombatState = {
+      ...s,
+      challengeAdvantage: 'player',
+      player: { ...s.player, selectedGambit: null, selectedWeaponProfile: powerSwordProfile },
+      ai:     { ...s.ai,     selectedGambit: null, selectedWeaponProfile: simpleMeleeProfile },
+    };
+    // Hit rolls of 4 → all 5 hit (WS5 vs WS5 = TN 4+).
+    // Wound rolls of 3: normal TN 4+ → 3 < 4 → all fail (no Hatred bonus).
+    // No wounds → AI attacks (4 dice, all miss).
+    const dice = new FakeDiceRoller([
+      4,4,4,4,4,    // 5 hit rolls (TN 4+, all hit)
+      3,3,3,3,3,    // 5 wound rolls (TN 4+: 3 < 4 → all fail; no Hatred bonus)
+      1,1,1,1,1,    // AI hit rolls (WS5 vs WS5 = 4+; all miss)
+    ]);
+    const result = resolveStrikeStep(dice, state, lib, dummy, 'player');
+    expect(result.playerResult.wounds).toBe(0);   // no Hatred bonus → all fail
+  });
+});

--- a/src/engine/gambitEffects.ts
+++ b/src/engine/gambitEffects.ts
@@ -480,6 +480,13 @@ export function getStrikeModifiers(
       // the engine: if reactive player, allows attacks after reaching 0W.
       return base;
 
+    // ── Legion Astartes Psychic Discipline gambits ───────────────────────────
+    case 'divination-every-strike-foreseen':
+      // WP check logic handled in strikeStep.ts (before hit rolls).
+      // On success, sets hitTNOverride = 2 so all hits succeed on 2+.
+      // No strike modifiers returned here.
+      return { ...base };
+
     default:
       return base;
   }

--- a/src/engine/strikeStep.ts
+++ b/src/engine/strikeStep.ts
@@ -76,6 +76,9 @@ function resolveAttackSequence(
   const log: string[] = [];
 
   // ── Compute effective stats ──────────────────────────────────────────────
+  // Roll D3 for weapons with 6+D3 attacks (e.g. Conflagration) before anything else.
+  const weaponD3 = (profile.attacksExtraD3 ?? false) ? dice.rollD3() : 0;
+
   // Only roll D3 when the gambit actually needs it (Flurry of Blows).
   // Calling rollD3() unconditionally would make the dice sequence
   // non-deterministic for every other gambit.
@@ -109,6 +112,8 @@ function resolveAttackSequence(
   let baseA = forceBoost === 'A' ? attackerChar.stats.A * 2 : attackerChar.stats.A;
   if (am.kind === 'add')   baseA += am.value;
   if (am.kind === 'fixed') baseA  = am.value;
+  // Conflagration: weapon has 6+D3 attacks (attacksExtraD3 flag)
+  if (profile.attacksExtraD3 ?? false) baseA += weaponD3;
 
   let atkA = mods.attacksOverride !== null
     ? mods.attacksOverride
@@ -166,10 +171,30 @@ function resolveAttackSequence(
     `${attackerChar.name} attacks: ${atkA} attacks, WS${atkWS} vs WS${defWS}, S${effectiveS} vs T${defT}${tNote}, AP${weaponAP ?? '-'}`,
   );
 
+  // Armourbane: no glancing-hit distinction for infantry; log only
+  if (profile.specialRules.some(sr => sr.name === 'Armourbane')) {
+    log.push('Armourbane: no glancing-hit distinction for infantry — rule has no effect here');
+  }
+
   // ── Hit Tests ────────────────────────────────────────────────────────────
   // Mirror-Form: Adamus hits always on 4+ regardless of WS comparison
   const mirrorFormActive = attacker.selectedGambit === 'mirror-form';
   const hitTN = mirrorFormActive ? 4 : getHitTargetNumber(atkWS, defWS);
+
+  // Divination — Every Strike Foreseen: WP check (no Perils).
+  // If successful, all Hit Tests succeed on 2+ for this attack sequence.
+  let hitTNOverride: number | null = null;
+  if (attacker.selectedGambit === 'divination-every-strike-foreseen') {
+    const [d1, d2] = dice.rollNd6(2);
+    const total   = d1 + d2;
+    const success = total <= attackerChar.stats.WP;
+    log.push(
+      `Every Strike Foreseen: ${d1}+${d2}=${total} vs WP${attackerChar.stats.WP} — ` +
+      (success ? 'hit on 2+' : 'normal hits'),
+    );
+    if (success) hitTNOverride = 2;
+  }
+
   const hitRolls = dice.rollNd6(atkA);
   let hits = 0;
   let critHits = 0;
@@ -185,7 +210,8 @@ function resolveAttackSequence(
     // Track unmodified 1s for Biological Overload
     if (roll === 1) hitRollOnes++;
 
-    const isHit = hitTN <= 6 && roll >= hitTN;
+    const effectiveHitTN = hitTNOverride ?? hitTN;
+    const isHit = effectiveHitTN <= 6 && roll >= effectiveHitTN;
 
     // Critical Hit only applies when a hit is actually inflicted by this Hit Test
     // (rule: "if a Hit is inflicted by that Hit Test, that Hit becomes a Critical Hit")
@@ -214,7 +240,7 @@ function resolveAttackSequence(
 
   const normalHits = hits - critHits;
   const critHitNote = critHits > 0 ? ` (${critHits} critical)` : '';
-  log.push(`Hit rolls [${hitRolls.join(',')}] needing ${hitTN}+ → ${hits} hit(s)${critHitNote}`);
+  log.push(`Hit rolls [${hitRolls.join(',')}] needing ${hitTNOverride ?? hitTN}+ → ${hits} hit(s)${critHitNote}`);
 
   if (hits === 0) {
     const defWounds = defender.currentWounds;
@@ -229,6 +255,13 @@ function resolveAttackSequence(
   }
 
   // ── Wound Tests ──────────────────────────────────────────────────────────
+  // Hatred(Psykers): +1 to wound tests when the defender has the Psyker rule
+  const attackerHatredPsykers = attackerChar.specialRules.some(
+    sr => sr.name === 'Hatred' && sr.target === 'Psykers',
+  );
+  const defenderIsPsyker = defenderChar.specialRules.some(sr => sr.name === 'Psyker');
+  const woundTestBonus = (attackerHatredPsykers && defenderIsPsyker) ? 1 : 0;
+
   // Base wound TN uses effectiveDefT (may be overridden by Steadfast Resilience / Tempered by War)
   const baseWoundTN = getWoundTargetNumber(effectiveS, effectiveDefT);
 
@@ -266,9 +299,12 @@ function resolveAttackSequence(
       : baseWoundTN;
 
     // Poisoned: use whichever TN is easier (lower number = easier to wound)
-    const woundTN = poisonedTN !== null
+    let woundTN = poisonedTN !== null
       ? Math.min(tableWoundTN, poisonedTN)
       : tableWoundTN;
+
+    // Hatred(Psykers): +1 to wound tests (lower TN by 1, minimum 2)
+    if (woundTestBonus > 0) woundTN = Math.max(2, woundTN - woundTestBonus);
 
     let isWound = woundTN <= 6 && roll >= woundTN;
     for (const sr of profile.specialRules) {
@@ -297,12 +333,15 @@ function resolveAttackSequence(
 
   const phageNote    = mods.phageToughness ? ' (Phage: T reduces per wound)' : '';
   const poisonNote   = poisonedTN !== null ? ` (Poisoned ${poisonedTN}+, table ${baseWoundTN})` : '';
-  const effectiveWoundTN = poisonedTN !== null ? Math.min(baseWoundTN, poisonedTN) : baseWoundTN;
+  const hatredNote   = woundTestBonus > 0 ? ` (Hatred +1 wound bonus)` : '';
+  const effectiveWoundTN = poisonedTN !== null
+    ? Math.max(2, Math.min(baseWoundTN, poisonedTN) - woundTestBonus)
+    : Math.max(2, baseWoundTN - woundTestBonus);
   if (critWounds > 0) {
     log.push(`${critHits} Critical Hit(s) → ${critWounds} automatic wound(s) (counts as roll of 6)`);
   }
   if (normalHits > 0) {
-    log.push(`Wound rolls [${woundRolls.join(',')}] needing ${effectiveWoundTN}+${poisonNote}${phageNote} → ${normalWounds} wound(s)`);
+    log.push(`Wound rolls [${woundRolls.join(',')}] needing ${effectiveWoundTN}+${poisonNote}${hatredNote}${phageNote} → ${normalWounds} wound(s)`);
   }
 
   if (wounds === 0) {
@@ -328,6 +367,8 @@ function resolveAttackSequence(
 
   let saved             = 0;
   let unsavedCritWounds = 0;
+  // Tracks wounds that fail saves (before FNP) for Deflagrate triggering
+  let deflagrateUnsavedCount = 0;
   let evsfUsed          = false; // Every Strike Foreseen may only re-roll ONE failed save
 
   // Pool 1: crit wounds at weapon AP — track each failure as an unsaved crit wound
@@ -343,10 +384,11 @@ function resolveAttackSequence(
         evsfUsed = true;
       }
       if (roll >= effectiveSave) saved++;
-      else unsavedCritWounds++;
+      else { unsavedCritWounds++; deflagrateUnsavedCount++; }
     }
   } else {
     unsavedCritWounds += critNormalCount;
+    deflagrateUnsavedCount += critNormalCount;
   }
 
   // Pool 2: normal wounds at weapon AP
@@ -362,7 +404,10 @@ function resolveAttackSequence(
         evsfUsed = true;
       }
       if (roll >= effectiveSave) saved++;
+      else deflagrateUnsavedCount++;
     }
+  } else {
+    deflagrateUnsavedCount += normNormalCount;
   }
 
   // Pool 3: crit breaching wounds at AP2 — track failures as unsaved crit wounds
@@ -378,10 +423,11 @@ function resolveAttackSequence(
         evsfUsed = true;
       }
       if (roll >= breachSave) saved++;
-      else unsavedCritWounds++;
+      else { unsavedCritWounds++; deflagrateUnsavedCount++; }
     }
   } else {
     unsavedCritWounds += critBreachingWounds;
+    deflagrateUnsavedCount += critBreachingWounds;
   }
 
   // Pool 4: normal breaching wounds at AP2
@@ -397,7 +443,10 @@ function resolveAttackSequence(
         evsfUsed = true;
       }
       if (roll >= breachSave) saved++;
+      else deflagrateUnsavedCount++;
     }
+  } else {
+    deflagrateUnsavedCount += normalBreachingWounds;
   }
 
   const saveRolls = [...critNormSaveRolls, ...normalSaveRolls, ...critBreachSaveRolls, ...normBreachSaveRolls];
@@ -434,7 +483,9 @@ function resolveAttackSequence(
     unsavedCritWounds = Math.min(unsavedCritWounds, unsavedWounds);
   }
 
-  if (unsavedWounds === 0) {
+  // Check if Deflagrate can still trigger (uses pre-FNP count)
+  const deflagrateRule = profile.specialRules.find(sr => sr.name === 'Deflagrate');
+  if (unsavedWounds === 0 && !(deflagrateRule && deflagrateUnsavedCount > 0)) {
     return {
       attackerName: attackerChar.name,
       attacks: atkA, hitRolls, hits,
@@ -479,14 +530,14 @@ function resolveAttackSequence(
     : 0;
   const shredDmgPerWound     = Math.max(1, (baseDmg + mods.damageDelta + 1) - ewReduction);
   const critShredDmgPerWound = Math.max(1, (baseDmg + mods.damageDelta + 2) - ewReduction);
-  const totalDamage =
+  let totalDamage =
     (unsavedCritWounds - unsavedCritShredWounds) * critDmgPerWound +
     unsavedCritShredWounds * critShredDmgPerWound +
     (unsavedNormalWounds - unsavedShredWounds) * dmgPerWound +
     unsavedShredWounds * shredDmgPerWound;
 
-  const defenderWoundsRemaining = Math.max(0, defender.currentWounds - totalDamage);
-  const defenderIsCasualty = defenderWoundsRemaining <= 0;
+  let defenderWoundsRemaining = Math.max(0, defender.currentWounds - totalDamage);
+  let defenderIsCasualty = defenderWoundsRemaining <= 0;
 
   const critNonShredCount = unsavedCritWounds - unsavedCritShredWounds;
   const critDmgNote = critNonShredCount > 0
@@ -498,11 +549,34 @@ function resolveAttackSequence(
   const shredNote = unsavedShredWounds > 0
     ? ` (${unsavedShredWounds} Shred wound(s) at +1 dmg)`
     : '';
-  log.push(
-    `${unsavedWounds} unsaved wound(s) × ${dmgPerWound} dmg${critDmgNote}${critShredNote}${shredNote} = ${totalDamage} damage. ` +
-    `${defenderChar.name}: ${defender.currentWounds} → ${defenderWoundsRemaining} wounds` +
-    (defenderIsCasualty ? ' (CASUALTY)' : ''),
-  );
+  if (unsavedWounds > 0) {
+    log.push(
+      `${unsavedWounds} unsaved wound(s) × ${dmgPerWound} dmg${critDmgNote}${critShredNote}${shredNote} = ${totalDamage} damage. ` +
+      `${defenderChar.name}: ${defender.currentWounds} → ${defenderWoundsRemaining} wounds` +
+      (defenderIsCasualty ? ' (CASUALTY)' : ''),
+    );
+  }
+
+  // ── Deflagrate ──────────────────────────────────────────────────────────
+  // Unsaved wounds from a weapon with Deflagrate(X) generate additional
+  // automatic hits at S(X) AP- D1 against the same target.
+  if (deflagrateRule && deflagrateUnsavedCount > 0 && !defenderIsCasualty) {
+    const extra = resolveDeflagrateGroup(
+      dice, deflagrateUnsavedCount, deflagrateRule.value,
+      defenderChar, effectiveDefT, log,
+    );
+    if (extra.damage > 0) {
+      const prevWounds = defenderWoundsRemaining;
+      defenderWoundsRemaining = Math.max(0, defenderWoundsRemaining - extra.damage);
+      defenderIsCasualty = defenderWoundsRemaining <= 0;
+      log.push(
+        `Deflagrate: ${extra.damage} extra damage. ` +
+        `${defenderChar.name}: ${prevWounds} → ${defenderWoundsRemaining} wounds` +
+        (defenderIsCasualty ? ' (CASUALTY)' : ''),
+      );
+      totalDamage += extra.damage;
+    }
+  }
 
   return {
     attackerName: attackerChar.name,
@@ -589,6 +663,74 @@ function applyDutyIsSacrificeWounds(
   }
   if (current <= 0) log.push(`  ${selfChar.name} is removed as a Casualty!`);
   return { newWounds: current, isCasualty: current <= 0 };
+}
+
+/**
+ * Resolve Deflagrate extra hits.
+ *
+ * For each unsaved wound caused by a weapon with Deflagrate(X), one extra
+ * automatic hit is inflicted at Strength X, AP -, D1.  The defender always
+ * benefits from their best available save (armour or invulnerable, whichever
+ * is better) since the hit is AP-.
+ *
+ * @param hits          - number of extra hits (= unsaved wounds that triggered Deflagrate)
+ * @param strength      - the Deflagrate Strength value
+ * @param defenderChar  - full character record of the defender
+ * @param effectiveDefT - defender's effective Toughness
+ * @param log           - log array to append messages to
+ */
+function resolveDeflagrateGroup(
+  dice: DiceRoller,
+  hits: number,
+  strength: number,
+  defenderChar: Character,
+  effectiveDefT: number,
+  log: string[],
+): { damage: number } {
+  const woundTN = getWoundTargetNumber(strength, effectiveDefT);
+  const woundRolls = dice.rollNd6(hits);
+  let wounds = 0;
+  for (const roll of woundRolls) {
+    if (woundTN <= 6 && roll >= woundTN) wounds++;
+  }
+  log.push(
+    `Deflagrate(${strength}): ${hits} extra hit(s) → wound rolls [${woundRolls.join(',')}] needing ${woundTN}+ → ${wounds} wound(s)`,
+  );
+  if (wounds === 0) return { damage: 0 };
+
+  // AP -: defender always gets their best save (lower number = better)
+  const defSv  = defenderChar.stats.Sv;
+  const defInv = defenderChar.stats.Inv;
+  const bestSave = defInv !== null ? Math.min(defSv, defInv) : defSv;
+  const saveRolls = dice.rollNd6(wounds);
+  let saved = 0;
+  for (const roll of saveRolls) {
+    if (roll >= bestSave) saved++;
+  }
+  log.push(`Deflagrate saves [${saveRolls.join(',')}] vs ${bestSave}+ → ${saved} saved`);
+  let unsaved = wounds - saved;
+
+  // Feel No Pain applies to Deflagrate wounds
+  let fnpThreshold: number | null = null;
+  for (const sr of defenderChar.specialRules) {
+    if (sr.name === 'FeelNoPain') fnpThreshold = sr.threshold;
+  }
+  if (fnpThreshold !== null && unsaved > 0) {
+    const fnpRolls = dice.rollNd6(unsaved);
+    const fnpSaved = fnpRolls.filter(r => r >= fnpThreshold!).length;
+    log.push(`Deflagrate FNP ${fnpThreshold}+: rolls [${fnpRolls.join(',')}] → ${fnpSaved} cancelled`);
+    unsaved -= fnpSaved;
+  }
+
+  if (unsaved === 0) return { damage: 0 };
+
+  // D1 damage per unsaved wound, reduced by Eternal Warrior (minimum 1)
+  let ewReduction = 0;
+  for (const sr of defenderChar.specialRules) {
+    if (sr.name === 'EternalWarrior') ewReduction = sr.value;
+  }
+  const dmgPerWound = Math.max(1, 1 - ewReduction);
+  return { damage: unsaved * dmgPerWound };
 }
 
 /**

--- a/src/models/character.ts
+++ b/src/models/character.ts
@@ -1,6 +1,18 @@
 import type { Weapon, SpecialRule } from './weapon.js';
 import type { GambitId } from './gambit.js';
 
+/**
+ * Available Psychic Disciplines for Legion Astartes Librarian characters.
+ * Each discipline grants a melee psychic weapon and/or character-level
+ * special rules / gambits that affect the Challenge Phase.
+ */
+export type PsychicDiscipline =
+  | 'biomancy'
+  | 'pyromancy'
+  | 'telekinesis'
+  | 'divination'
+  | 'thaumaturgy';
+
 /** Sub-types that a model may have in addition to its primary Type. */
 export type ModelSubType =
   | 'Command'
@@ -58,4 +70,10 @@ export interface Character {
    * Used by the Eversor ('biological-overload') and Adamus ('mirror-form') assassins.
    */
   mandatoryGambitId?: GambitId;
+  /**
+   * If set, the character may choose a Psychic Discipline on the selection
+   * screen, which adds the discipline's weapon, special rules, and gambits.
+   * Only applies to Legion Astartes Librarian characters.
+   */
+  availablePsychicDisciplines?: PsychicDiscipline[];
 }

--- a/src/models/gambit.ts
+++ b/src/models/gambit.ts
@@ -77,7 +77,9 @@ export type GambitId =
   | 'i-am-alpharius'          // all AL: first round; set opponent's CI to 1
   // ── Divisio Assassinorum mandatory gambits ───────────────────────────────
   | 'biological-overload'    // Eversor mandatory: +3 Focus; +3A; self-wound on hit rolls of 1
-  | 'mirror-form';           // Adamus mandatory: hits on 4+; fight after reaching 0W if reactive
+  | 'mirror-form'            // Adamus mandatory: hits on 4+; fight after reaching 0W if reactive
+  // ── Legion Astartes Psychic Discipline gambits ───────────────────────────
+  | 'divination-every-strike-foreseen'; // Divination: WP check → hit on 2+ this Strike Step
 
 /**
  * When within the Challenge procedure a gambit has its primary effect.

--- a/src/models/weapon.ts
+++ b/src/models/weapon.ts
@@ -40,7 +40,10 @@ export type SpecialRule =
   | { name: 'Poisoned';         threshold: number }   // wound always on roll ≥ threshold (ignores S vs T comparison)
   | { name: 'PraeternaturalResilience' }              // CriticalHit(X) attacks against this model use X=6 (raises threshold to 6+)
   | { name: 'SublimeSwordsman' }                      // +1A per point this model's Base I exceeds opponent's, when this model has Challenge Advantage
-  | { name: 'Force'; characteristic: 'S' | 'A' | 'D' | 'AP' | 'I' | 'WS' };  // WP check (2d6≤WP): doubles characteristic X; doubles trigger Perils of the Warp
+  | { name: 'Force'; characteristic: 'S' | 'A' | 'D' | 'AP' | 'I' | 'WS' }  // WP check (2d6≤WP): doubles characteristic X; doubles trigger Perils of the Warp
+  | { name: 'Armourbane' }              // AP 1 vs vehicles; infantry get no benefit — logged only
+  | { name: 'Deflagrate'; value: number }  // unsaved wounds generate extra S(X)/AP-/D1 hits
+  | { name: 'Psyker' };               // marks model as a Psyker for Hatred(Psykers) targeting
   // Rules intentionally not simulated:
   //   Bypass(X+) — Phase sword's bypass of all saves; omitted (no Bypass special rule added)
   //   Phage(S)   — established pattern (daemon weapons); omit from profiles
@@ -57,6 +60,12 @@ export interface WeaponProfile {
   ap: number | null;
   damage: number;
   specialRules: SpecialRule[];
+  /**
+   * If true, roll a D3 at the start of the attack sequence and add it to
+   * the Attacks total (after applying the attacksModifier).
+   * Used by Conflagration (6+D3 attacks).
+   */
+  attacksExtraD3?: boolean;
 }
 
 /** A weapon, which may have multiple profiles (e.g., melee + ranged). */

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -10,7 +10,9 @@
 import type { Character } from '../models/character.js';
 import type { CombatState } from '../models/combatState.js';
 import type { GambitId } from '../models/gambit.js';
+import type { PsychicDiscipline } from '../models/character.js';
 import { getCharacterById } from '../data/factions/index.js';
+import { applyDiscipline } from '../data/psychicDisciplines.js';
 import { ChallengeEngine, buildInitialState } from '../engine/challengeEngine.js';
 import { RealDiceRoller } from '../engine/dice.js';
 import { mountSelectionScreen, type SelectionResult } from './screens/selectionScreen.js';
@@ -60,7 +62,11 @@ export function startApp(container: HTMLElement): void {
       container,
       (result) => {
         app.selectionSnapshot   = result;
-        app.playerChar          = getCharacterById(result.playerCharId) ?? null;
+        let playerChar = getCharacterById(result.playerCharId) ?? null;
+        if (result.playerDiscipline && playerChar) {
+          playerChar = applyDiscipline(playerChar, result.playerDiscipline as PsychicDiscipline);
+        }
+        app.playerChar          = playerChar;
         app.aiChar              = getCharacterById(result.aiCharId) ?? null;
         app.playerWeaponIndex   = result.playerWeaponIndex;
         app.playerProfileIndex  = result.playerProfileIndex;
@@ -68,7 +74,11 @@ export function startApp(container: HTMLElement): void {
       },
       (result) => {
         app.selectionSnapshot   = result;
-        app.playerChar          = getCharacterById(result.playerCharId) ?? null;
+        let playerChar = getCharacterById(result.playerCharId) ?? null;
+        if (result.playerDiscipline && playerChar) {
+          playerChar = applyDiscipline(playerChar, result.playerDiscipline as PsychicDiscipline);
+        }
+        app.playerChar          = playerChar;
         app.aiChar              = getCharacterById(result.aiCharId) ?? null;
         app.playerWeaponIndex   = result.playerWeaponIndex;
         app.playerProfileIndex  = result.playerProfileIndex;

--- a/src/ui/screens/selectionScreen.ts
+++ b/src/ui/screens/selectionScreen.ts
@@ -6,13 +6,15 @@
  * Character filter bar (above the row) lets the user narrow both dropdowns to:
  *   All | Primarchs only | Legion Astartes only
  */
-import type { Character } from '../../models/character.js';
+import type { Character, PsychicDiscipline } from '../../models/character.js';
 import type { CharModifier } from '../../models/weapon.js';
+import type { Weapon } from '../../models/weapon.js';
 import {
   ALL_CHARACTERS,
   getFactionLabel,
   getCharactersByFaction,
 } from '../../data/factions/index.js';
+import { DISCIPLINE_CONFIGS } from '../../data/psychicDisciplines.js';
 import { renderStatBlock } from '../components/statBlock.js';
 
 export interface SelectionResult {
@@ -22,6 +24,8 @@ export interface SelectionResult {
   playerProfileIndex: number;
   /** Active filter at the time this result was captured. */
   filter: CharacterFilter;
+  /** Selected Psychic Discipline (only for Librarian characters). */
+  playerDiscipline?: string;
 }
 
 // ── Filter types ──────────────────────────────────────────────────────────────
@@ -105,6 +109,17 @@ function buildHTML(): string {
               <select id="player-char-select" class="form-select form-select-sm bg-dark text-white border-secondary mb-2">
                 <option value="">— Select a character —</option>
               </select>
+              <div id="player-discipline-section" hidden>
+                <label class="form-label small text-muted">Psychic Discipline:</label>
+                <select id="player-discipline-select" class="form-select form-select-sm bg-dark text-white border-secondary mb-2">
+                  <option value="">— No Discipline —</option>
+                  <option value="biomancy">Biomancy (Biomantic Slam)</option>
+                  <option value="pyromancy">Pyromancy (Conflagration)</option>
+                  <option value="telekinesis">Telekinesis (no melee weapon)</option>
+                  <option value="divination">Divination (DuellistsEdge +2, Every Strike Foreseen)</option>
+                  <option value="thaumaturgy">Thaumaturgy (Hatred: Psykers)</option>
+                </select>
+              </div>
               <div id="player-weapon-section" hidden>
                 <label class="form-label small text-muted">Starting weapon:</label>
                 <select id="player-weapon-select" class="form-select form-select-sm bg-dark text-white border-secondary mb-2">
@@ -162,14 +177,16 @@ function attachListeners(
   onAbout: (snapshot: SelectionResult) => void,
   initialState?: SelectionResult,
 ): void {
-  const playerSelect  = container.querySelector<HTMLSelectElement>('#player-char-select')!;
-  const weaponSection = container.querySelector<HTMLElement>('#player-weapon-section')!;
-  const weaponSelect  = container.querySelector<HTMLSelectElement>('#player-weapon-select')!;
-  const aiSelect      = container.querySelector<HTMLSelectElement>('#ai-char-select')!;
-  const beginBtn      = container.querySelector<HTMLButtonElement>('#begin-btn')!;
-  const simulateBtn   = container.querySelector<HTMLButtonElement>('#simulate-btn')!;
-  const playerStat    = container.querySelector<HTMLElement>('#player-stat-block')!;
-  const aiStat        = container.querySelector<HTMLElement>('#ai-stat-block')!;
+  const playerSelect       = container.querySelector<HTMLSelectElement>('#player-char-select')!;
+  const disciplineSection  = container.querySelector<HTMLElement>('#player-discipline-section')!;
+  const disciplineSelect   = container.querySelector<HTMLSelectElement>('#player-discipline-select')!;
+  const weaponSection      = container.querySelector<HTMLElement>('#player-weapon-section')!;
+  const weaponSelect       = container.querySelector<HTMLSelectElement>('#player-weapon-select')!;
+  const aiSelect           = container.querySelector<HTMLSelectElement>('#ai-char-select')!;
+  const beginBtn           = container.querySelector<HTMLButtonElement>('#begin-btn')!;
+  const simulateBtn        = container.querySelector<HTMLButtonElement>('#simulate-btn')!;
+  const playerStat         = container.querySelector<HTMLElement>('#player-stat-block')!;
+  const aiStat             = container.querySelector<HTMLElement>('#ai-stat-block')!;
 
   const updateBeginBtn = () => {
     const ready = Boolean(playerSelect.value && aiSelect.value);
@@ -221,11 +238,22 @@ function attachListeners(
 
     refreshSelects(initialState.filter);
 
-    // Restore player character and weapon
+    // Restore player character, discipline, and weapon
     playerSelect.value = initialState.playerCharId;
     const savedPlayerChar = ALL_CHARACTERS.find(c => c.id === initialState.playerCharId);
     if (savedPlayerChar) {
-      populateWeaponSelect(savedPlayerChar, weaponSelect, weaponSection);
+      // Show discipline section if the character supports it
+      if (savedPlayerChar.availablePsychicDisciplines) {
+        disciplineSection.hidden = false;
+        if (initialState.playerDiscipline) {
+          disciplineSelect.value = initialState.playerDiscipline;
+        }
+      }
+      // Populate weapons — include the discipline weapon if one was selected
+      const savedDisciplineWeapon = initialState.playerDiscipline
+        ? DISCIPLINE_CONFIGS[initialState.playerDiscipline as PsychicDiscipline]?.meleeWeapon
+        : undefined;
+      populateWeaponSelect(savedPlayerChar, weaponSelect, weaponSection, savedDisciplineWeapon);
       weaponSelect.value = `${initialState.playerWeaponIndex}-${initialState.playerProfileIndex}`;
       playerStat.innerHTML = renderStatBlock(savedPlayerChar);
     }
@@ -252,13 +280,33 @@ function attachListeners(
   playerSelect.addEventListener('change', () => {
     const char = ALL_CHARACTERS.find(c => c.id === playerSelect.value);
     if (char) {
+      // Show/hide discipline section
+      if (char.availablePsychicDisciplines) {
+        disciplineSection.hidden = false;
+        disciplineSelect.value = ''; // reset discipline on character change
+      } else {
+        disciplineSection.hidden = true;
+        disciplineSelect.value = '';
+      }
+      // Populate base weapons only (no discipline selected yet after a character change)
       populateWeaponSelect(char, weaponSelect, weaponSection);
       playerStat.innerHTML = renderStatBlock(char);
     } else {
+      disciplineSection.hidden = true;
       weaponSection.hidden = true;
       playerStat.innerHTML = '';
     }
     updateBeginBtn();
+  });
+
+  // Discipline dropdown: repopulate weapon list when a discipline is selected
+  disciplineSelect.addEventListener('change', () => {
+    const char = ALL_CHARACTERS.find(c => c.id === playerSelect.value);
+    if (char) {
+      const disc = disciplineSelect.value as PsychicDiscipline | '';
+      const disciplineWeapon = disc ? DISCIPLINE_CONFIGS[disc]?.meleeWeapon : undefined;
+      populateWeaponSelect(char, weaponSelect, weaponSection, disciplineWeapon);
+    }
   });
 
   aiSelect.addEventListener('change', () => {
@@ -276,6 +324,7 @@ function attachListeners(
       playerWeaponIndex: wIdx,
       playerProfileIndex: pIdx,
       filter: (checkedFilter?.value ?? 'all') as CharacterFilter,
+      playerDiscipline: disciplineSelect.value || undefined,
     };
   };
 
@@ -295,11 +344,14 @@ function attachListeners(
 /**
  * Populate the weapon dropdown from a character's melee weapons.
  * Shows the section when the character has options; auto-selects the first.
+ *
+ * @param extraWeapon - optional discipline weapon appended at index char.weapons.length
  */
 function populateWeaponSelect(
   char: Character,
   selectEl: HTMLSelectElement,
   sectionEl: HTMLElement,
+  extraWeapon?: Weapon,
 ): void {
   const options: string[] = [];
 
@@ -313,6 +365,18 @@ function populateWeaponSelect(
       );
     });
   });
+
+  // Extra weapon (e.g. discipline weapon) is appended at index char.weapons.length
+  if (extraWeapon && extraWeapon.type === 'melee') {
+    const extraWIdx = char.weapons.length;
+    extraWeapon.profiles.forEach((profile, pIdx) => {
+      const sStr = resolveStrength(char.stats.S, profile.strengthModifier);
+      const apStr = profile.ap !== null ? `AP${profile.ap}` : 'AP-';
+      options.push(
+        `<option value="${extraWIdx}-${pIdx}">${profile.profileName} — S${sStr} ${apStr} D${profile.damage}</option>`,
+      );
+    });
+  }
 
   selectEl.innerHTML = options.join('');
   selectEl.disabled  = options.length <= 1;


### PR DESCRIPTION
…ians

Adds five psychic disciplines (Biomancy, Pyromancy, Telekinesis, Divination, Thaumaturgy) selectable for Librarian characters on the selection screen.

- New weapons: Biomantic Slam (Force(D), Armourbane, AP2, D2, S12) and Conflagration (Deflagrate(5), AP4, D1, S5, 6+D3 attacks)
- New mechanics in strikeStep: attacksExtraD3 (Conflagration), Deflagrate unsaved-wound follow-up hits, Every Strike Foreseen hit-TN override, Hatred(Psykers) wound-TN bonus
- New gambit: divination-every-strike-foreseen (WP check → hit on 2+)
- applyDiscipline() merges weapons/rules/gambits onto a cloned Character
- Selection screen shows discipline dropdown for Librarian characters and restores discipline selection in the snapshot
- 6 new engine tests covering all new mechanics (113 total, all passing)